### PR TITLE
Add CFR changes table of contents

### DIFF
--- a/regulations/templates/regulations/preamble-chrome.html
+++ b/regulations/templates/regulations/preamble-chrome.html
@@ -6,6 +6,7 @@
 {% block sidebar-icons %}
 <li><a href="#table-of-contents" id="menu-link" class="toc-nav-link current" title="Table of Contents"><span class="icon-text">Table of Contents</span><img src="{%static "regulations/img/table-of-contents.svg" %}"
        class="drawer-toggle-icon" alt="Table of Contents toggle" /></a></li>
+<li><a href="#timeline" id="timeline-link" class="toc-nav-link" title="CFR Changes">CFR</a></li>
 {% endblock %}
 
 {% block wayfinding %}
@@ -41,6 +42,32 @@
           {% endif %}
         {% endfor %}
       </ol>
+    </nav>
+  </div>
+
+  {% comment %}
+  @TODO: "timeline" is not an accurate description here, but the JS has a
+  whitelist which needs to be followed. We can follow up to generalize the JS
+  {% endcomment %}
+  <div id="timeline" class="toc-container hidden">
+    <div class="drawer-header">
+      <h3 class="toc-type">Table of Contents</h3>
+    </div>
+    <nav id="cfr-toc" class="regulation-nav drawer-content" role="navigation">
+      <ol>
+        {% for cfr_part_toc in cfr_change_toc %}
+          <li>
+            <h3 class="subpart-heading">{{cfr_part_toc.title}} CFR {{cfr_part_toc.part}}</h3>
+          </li>
+          <li><a href="{{cfr_part_toc.authority_url}}">Authority</a></li>
+          {% for section_toc in cfr_part_toc.sections %}
+            <li><a href="{{section_toc.url}}">{{section_toc.title}}</a></li>
+          {% endfor %}
+        {% endfor %}
+      </ol>
+      {% with toc_items=TOC %}
+        {% include "regulations/toc.html" %}
+      {% endwith %}
     </nav>
   </div>
 </div> <!-- /.panel -->

--- a/regulations/tests/views_preamble_tests.py
+++ b/regulations/tests/views_preamble_tests.py
@@ -31,9 +31,10 @@ class PreambleViewTests(TestCase):
         self.assertIsNone(fn(root, ['1', 'c', 'r']))
         self.assertIsNone(fn(root, ['1', 'c', 'i', 'r']))
 
+    @patch('regulations.views.preamble.CFRChangeToC')
     @patch('regulations.generator.generator.api_reader')
     @patch('regulations.views.preamble.ApiReader')
-    def test_get_integration(self, ApiReader, api_reader):
+    def test_get_integration(self, ApiReader, api_reader, CFRChangeToC):
         """Verify that the contexts are built correctly before being sent to
         the template. AJAX/partial=true requests should only get the inner
         context (i.e. no UI-related context)"""
@@ -90,3 +91,49 @@ class PreambleViewTests(TestCase):
         self.assertRaises(Http404, view,
                           RequestFactory().get('/preamble/1/not/here'),
                           paragraphs='1/not/here')
+
+
+class CFRChangeToCTests(TestCase):
+    @patch('regulations.views.preamble.fetch_toc')
+    @patch('regulations.views.preamble.utils.regulation_meta')
+    def test_add_amendment(self, fetch_meta, fetch_toc):
+        """Add amendments for two different CFR parts. Verify that the table
+        of contents contains only the changed data"""
+        version_info = {'111': {'left': 'v1', 'right': 'v2'},
+                        '222': {'left': 'vold', 'right': 'vnew'}}
+        builder = preamble.CFRChangeToC('docdoc', version_info)
+        fetch_toc.return_value = [
+            dict(index=['111', '1'], title='Section 1'),
+            dict(index=['111', '1', 'a'], title='1 a'),
+            dict(index=['111', '2'], title='Section 2'),
+            dict(index=['111', '3'], title='Section 3')]
+        fetch_meta.return_value = dict(cfr_title_number='99',
+                                       statutory_name='Some title for reg 111')
+        builder.add_amendment(dict(cfr_part='111', instruction='1. inst1',
+                                   authority='auth1'))
+        builder.add_amendment(dict(cfr_part='111', instruction='2. inst2',
+                                   # The second element of each pair would be
+                                   # non-empty in realistic scenarios
+                                   changes=[['111-1', []], ['111-3-b', []]]))
+
+        fetch_toc.return_value = [dict(index=['222', '4'], title='Section 4')]
+        fetch_meta.return_value = dict(cfr_title_number='99',
+                                       statutory_name='Some title for reg 222')
+        # only authority change
+        builder.add_amendment(dict(cfr_part='222', instruction='3. inst3',
+                                   authority='auth2'))
+
+        self.assertEqual(builder.toc, [
+            preamble.ToCPart(
+                title='99', part='111', name='Some title for reg 111',
+                authority_url='/preamble/docdoc/cfr_changes/111',
+                sections=[
+                    preamble.ToCSect(section='1', title='Section 1',
+                                     url='/preamble/docdoc/cfr_changes/111-1'),
+                    preamble.ToCSect(section='3', title='Section 3',
+                                     url='/preamble/docdoc/cfr_changes/111-3')
+                ]),
+            preamble.ToCPart(
+                title='99', part='222', name='Some title for reg 222',
+                authority_url='/preamble/docdoc/cfr_changes/222',
+                sections=[])])


### PR DESCRIPTION
Very rough pass at adding a list of modified sections/authorities to the
drawer when viewing a proposed rule. This ToC is built from the list of
changes, the meta data, and the toc data for the "new" version of the
regulation.

Pain points which this punts on:
1) "timeline" is the wrong name for this tab, but it's one that the JS
understands. Rather than try to figure out how to generalize that, this just
co-opts the term.
2) The order of "changes" matters -- we previously used a dictionary. This
assumes a list of key-value pairs is used instead and converts any
dictionaries into that format

Resolves eregs/notice-and-comment#96