### PR TITLE
Add ajax navigation to cfr changes toc.

### DIFF
--- a/regulations/static/regulations/js/source/app-init.js
+++ b/regulations/static/regulations/js/source/app-init.js
@@ -25,11 +25,11 @@ Backbone.$ = $;
     init: function() {
         Router.start();
         this.bindEvents();
-        var gaview = new AnalyticsHandler(),
-            main = new MainView(),
-            sidebar = new SidebarView(),
-            header = new HeaderView(),  // Header before Drawer as Drawer sends Header events
-            drawer = new DrawerView();
+        var gaview = new AnalyticsHandler();
+        var header = new HeaderView();  // Header before Drawer as Drawer sends Header events
+        var drawer = new DrawerView();
+        var main = new MainView();
+        var sidebar = new SidebarView();
         setTimeout(function() {
             $('html').addClass('selenium-start');
         }, 5000);

--- a/regulations/static/regulations/js/source/views/comment/comment-index-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-index-view.js
@@ -49,7 +49,9 @@ module.exports = Backbone.CommentIndexView = Backbone.View.extend({
 
   editComment: function(e) {
     var options = _.extend({mode: 'write'}, getOptions(e.target));
+    var type = options.section.split('-')[1];
     DrawerEvents.trigger('section:open', options.section);
+    DrawerEvents.trigger('pane:change', type === 'preamble' ? 'table-of-contents' : 'table-of-contents-secondary');
     MainEvents.trigger('section:open', options.section, options, 'preamble-section');
     CommentEvents.trigger('comment:writeTabOpen');
   },

--- a/regulations/static/regulations/js/source/views/drawer/drawer-tabs-view.js
+++ b/regulations/static/regulations/js/source/views/drawer/drawer-tabs-view.js
@@ -17,6 +17,7 @@ var DrawerTabsView = Backbone.View.extend({
 
     idMap: {
         'table-of-contents': '#menu-link',
+        'table-of-contents-secondary': '#table-of-contents-secondary-link',
         'timeline': '#timeline-link',
         'search': '#search-link'
     },

--- a/regulations/static/regulations/js/source/views/drawer/drawer-view.js
+++ b/regulations/static/regulations/js/source/views/drawer/drawer-view.js
@@ -27,6 +27,11 @@ var DrawerView = Backbone.View.extend({
         this.childViews['search'] = new SearchView();
         this.childViews['drawer-tabs'] = new DrawerTabs();
 
+        var $tocSecondary = $('table-of-contents-secondary');
+        if ($tocSecondary.length) {
+          this.childViews['table-of-contents-secondary'] = new TOCView({el: $tocSecondary});
+        }
+
         this.setActivePane('table-of-contents');
     },
 

--- a/regulations/static/regulations/js/source/views/drawer/drawer-view.js
+++ b/regulations/static/regulations/js/source/views/drawer/drawer-view.js
@@ -27,7 +27,7 @@ var DrawerView = Backbone.View.extend({
         this.childViews['search'] = new SearchView();
         this.childViews['drawer-tabs'] = new DrawerTabs();
 
-        var $tocSecondary = $('table-of-contents-secondary');
+        var $tocSecondary = $('#table-of-contents-secondary');
         if ($tocSecondary.length) {
           this.childViews['table-of-contents-secondary'] = new TOCView({el: $tocSecondary});
         }

--- a/regulations/static/regulations/js/source/views/main/preamble-view.js
+++ b/regulations/static/regulations/js/source/views/main/preamble-view.js
@@ -11,6 +11,7 @@ var PreambleHeadView = require('../header/preamble-head-view');
 var CommentView = require('../comment/comment-view');
 var CommentIndexView = require('../comment/comment-index-view');
 var CommentEvents = require('../../events/comment-events');
+var DrawerEvents = require('../../events/drawer-events');
 var helpers = require('../../helpers');
 
 var PreambleView = ChildView.extend({
@@ -22,9 +23,13 @@ var PreambleView = ChildView.extend({
 
   initialize: function(options) {
     this.options = options;
-    this.id = options.id;
+
+    // If rendering, `MainView` passes the ID of the sub-section with the section ID;
+    // else, find the sub-section from `$el` and get its ID.
+    this.id = options.render ? options.id : this.$el.find('section:first').attr('id');
 
     var path = helpers.parsePreambleId(this.id);
+    var type = this.id.split('-')[1];
     this.url = path.join('/');
 
     if (!options.render) {
@@ -38,6 +43,7 @@ var PreambleView = ChildView.extend({
     this.listenTo(MainEvents, 'paragraph:active', this.handleParagraphActive);
 
     CommentEvents.trigger('comment:readTabOpen');
+    DrawerEvents.trigger('pane:init', type === 'preamble' ? 'table-of-contents' : 'table-of-contents-secondary');
   },
 
   handleRead: function() {

--- a/regulations/templates/regulations/preamble-chrome.html
+++ b/regulations/templates/regulations/preamble-chrome.html
@@ -61,7 +61,7 @@
           </li>
           <li><a href="{{cfr_part_toc.authority_url}}">Authority</a></li>
           {% for section_toc in cfr_part_toc.sections %}
-            <li><a href="{{section_toc.url}}" data-section-id="{{doc_number}}-cfr-{{cfr_part_toc.part}}-{{section_toc.section}}">{{section_toc.title}}</a></li>
+            <li><a href="{{section_toc.url}}" data-section-id="{{section_toc.full_id}}">{{section_toc.title}}</a></li>
           {% endfor %}
         {% endfor %}
       </ol>

--- a/regulations/templates/regulations/preamble-chrome.html
+++ b/regulations/templates/regulations/preamble-chrome.html
@@ -10,7 +10,7 @@
     <img src="{%static "regulations/img/table-of-contents.svg" %}" class="drawer-toggle-icon" alt="Table of Contents toggle" />
   </a>
 </li>
-<li><a href="#table-of-contents-secondary" id="timeline-link" class="toc-nav-link" title="CFR Changes">CFR</a></li>
+<li><a href="#table-of-contents-secondary" id="table-of-contents-secondary-link" class="toc-nav-link" title="CFR Changes">CFR</a></li>
 {% endblock %}
 
 {% block wayfinding %}
@@ -49,10 +49,6 @@
     </nav>
   </div>
 
-  {% comment %}
-  @TODO: "timeline" is not an accurate description here, but the JS has a
-  whitelist which needs to be followed. We can follow up to generalize the JS
-  {% endcomment %}
   <div id="table-of-contents-secondary" class="toc-container hidden">
     <div class="drawer-header">
       <h3 class="toc-type">Table of Contents</h3>

--- a/regulations/templates/regulations/preamble-chrome.html
+++ b/regulations/templates/regulations/preamble-chrome.html
@@ -10,7 +10,7 @@
     <img src="{%static "regulations/img/table-of-contents.svg" %}" class="drawer-toggle-icon" alt="Table of Contents toggle" />
   </a>
 </li>
-<li><a href="#timeline" id="timeline-link" class="toc-nav-link" title="CFR Changes">CFR</a></li>
+<li><a href="#table-of-contents-secondary" id="timeline-link" class="toc-nav-link" title="CFR Changes">CFR</a></li>
 {% endblock %}
 
 {% block wayfinding %}
@@ -35,12 +35,12 @@
           {% if child.title %}
             <li>
               <a href="{% url "chrome_preamble" paragraphs=child.label|join:"/" %}"
-                 data-section-id="{{section_prefix}}-{{child.label|join:"-"}}">{{child.title}}</a>
+                 data-section-id="{{doc_number}}-preamble-{{child.label|join:"-"}}">{{child.title}}</a>
             </li>
             {% for subchild in child.children %}
               {% if subchild.title %}
                 <li><a href="{% url "chrome_preamble" paragraphs=subchild.label|join:"/" %}"
-                       data-section-id="{{section_prefix}}-{{subchild.label|join:"-"}}"style="padding-left: 2em;">{{subchild.title}}</a></li>
+                       data-section-id="{{doc_number}}-preamble-{{subchild.label|join:"-"}}"style="padding-left: 2em;">{{subchild.title}}</a></li>
               {% endif %}
             {% endfor %}
           {% endif %}
@@ -53,7 +53,7 @@
   @TODO: "timeline" is not an accurate description here, but the JS has a
   whitelist which needs to be followed. We can follow up to generalize the JS
   {% endcomment %}
-  <div id="timeline" class="toc-container hidden">
+  <div id="table-of-contents-secondary" class="toc-container hidden">
     <div class="drawer-header">
       <h3 class="toc-type">Table of Contents</h3>
     </div>
@@ -65,13 +65,10 @@
           </li>
           <li><a href="{{cfr_part_toc.authority_url}}">Authority</a></li>
           {% for section_toc in cfr_part_toc.sections %}
-            <li><a href="{{section_toc.url}}">{{section_toc.title}}</a></li>
+            <li><a href="{{section_toc.url}}" data-section-id="{{doc_number}}-cfr-{{cfr_part_toc.part}}-{{section_toc.section}}">{{section_toc.title}}</a></li>
           {% endfor %}
         {% endfor %}
       </ol>
-      {% with toc_items=TOC %}
-        {% include "regulations/toc.html" %}
-      {% endwith %}
     </nav>
   </div>
 </div> <!-- /.panel -->

--- a/regulations/tests/views_preamble_tests.py
+++ b/regulations/tests/views_preamble_tests.py
@@ -129,9 +129,11 @@ class CFRChangeToCTests(TestCase):
                 authority_url='/preamble/docdoc/cfr_changes/111',
                 sections=[
                     preamble.ToCSect(section='1', title='Section 1',
-                                     url='/preamble/docdoc/cfr_changes/111-1'),
+                                     url='/preamble/docdoc/cfr_changes/111-1',
+                                     full_id='docdoc-cfr-111-1'),
                     preamble.ToCSect(section='3', title='Section 3',
-                                     url='/preamble/docdoc/cfr_changes/111-3')
+                                     url='/preamble/docdoc/cfr_changes/111-3',
+                                     full_id='docdoc-cfr-111-3')
                 ]),
             preamble.ToCPart(
                 title='99', part='222', name='Some title for reg 222',

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -50,7 +50,7 @@ def generate_html_tree(subtree, request, id_prefix=None):
 
 ToCPart = namedtuple('ToCPart', ['title', 'part', 'name', 'authority_url',
                                  'sections'])
-ToCSect = namedtuple('ToCSect', ['section', 'url', 'title'])
+ToCSect = namedtuple('ToCSect', ['section', 'url', 'title', 'full_id'])
 
 
 class CFRChangeToC(object):
@@ -108,12 +108,14 @@ class CFRChangeToC(object):
         if (self.current_section is None or
                 self.current_section.section != change_section):
 
+            section = '-'.join(label_parts[:2])
             self.current_section = ToCSect(
                 section=change_section,
                 title=self.section_titles.get(change_section),
+                full_id='{}-cfr-{}'.format(self.doc_number, section),
                 url=reverse('cfr_changes', kwargs={
                     'doc_number': self.doc_number,
-                    'section': '-'.join(label_parts[:2])}))
+                    'section': section}))
             self.current_part.sections.append(self.current_section)
 
     @classmethod

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -149,14 +149,12 @@ class PreambleView(View):
         context = generate_html_tree(subtree, request, id_prefix=id_prefix)
 
         context['use_comments'] = True
-        context['section_prefix'] = '{}-preamble'.format(doc_number)
         template = context['node']['template_name']
 
         context = {
             'sub_context': context,
             'sub_template': template,
             'preamble': preamble,
-            'section_prefix': '{}-preamble'.format(label_parts[0]),
             'doc_number': doc_number,
             'full_id': context['node']['full_id'],
             'cfr_change_toc': CFRChangeToC.for_doc_number(doc_number)


### PR DESCRIPTION
There's more to do here--I'm guessing we'll want to open the preamble toc panel when viewing a preamble section, and the cfr changes toc panel when viewing cfr changes, for example. We might also want to refactor `DrawerView` to hard-code less stuff, if possible (why are we instantiating views with no corresponding dom elements?). Happy to add more to this patch, or continue work elsewhere.

@cmc333333: there's more ugliness here around building section ids for the cfr changes toc. I can modify the toc generator to add prefixed fields if you think that's the right approach.