### PR TITLE
adding table of contents tab switcher to -site instead of notice-and-…

### DIFF
--- a/regulations/static/regulations/css/less/module/drawer-content.less
+++ b/regulations/static/regulations/css/less/module/drawer-content.less
@@ -39,7 +39,7 @@ This contains all of the styles specific to the TOC
     a:link,
     a:visited {
         color: @black;
-        .border-bottom-light (@width: 0px);
+        .border-bottom-light (@width: 1px);
     }
 
     a:hover,

--- a/regulations/templates/regulations/preamble-chrome.html
+++ b/regulations/templates/regulations/preamble-chrome.html
@@ -5,9 +5,8 @@
 
 {% block sidebar-icons %}
 <li>
-  <a href="#table-of-contents" id="menu-link" class="toc-nav-link current" title="Table of Contents">
-    <span class="icon-text">Table of Contents</span>
-    <img src="{%static "regulations/img/table-of-contents.svg" %}" class="drawer-toggle-icon" alt="Table of Contents toggle" />
+  <a href="#table-of-contents" id="menu-link" class="toc-nav-link current" title="Preamble Table of Contents">
+    <span class="menu-tab">Pre</span>
   </a>
 </li>
 <li>


### PR DESCRIPTION
…comment

Per the discussion in [Notice and Comment #101](https://github.com/eregs/notice-and-comment/pull/101) I'm moving these changes into -site.

