### PR TITLE
Cache comment models to S3 on sync.

### DIFF
--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -22,9 +22,8 @@ var comments = require('../../collections/comment-collection');
  * @param file {File} File to upload
  */
 function getUploadUrl(file) {
-  var prefix = window.APP_PREFIX || '/';
   return $.getJSON(
-    prefix + 'comments/attachment',
+    window.APP_PREFIX + 'comments/attachment',
     {size: file.size, name: file.name, type: file.type || 'application/octet-stream'}
   ).then(function(resp) {
     return resp;

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -45,6 +45,7 @@ urlpatterns = patterns(
     url(r'^$', universal, name='universal_landing'),
     # about page
     url(r'^about$', about, name='about'),
+    url(r'^comments/cache$', comment.cache_proxy),
     url(r'^comments/attachment$', comment.upload_proxy),
     url(r'^comments/review/(?P<doc_number>[\w-]+)$',
         PrepareCommentView.as_view(), name='comment_review'),


### PR DESCRIPTION
When the comments collection is synced to browser storage, cache all
comment models to S3 for retrieval in case the user loses access to
storage. The client either requests a random cache key on sync or uses
its existing cache key.

Based on conversation with @vrajmohan @tadhg-ohiggins @cmc333333 earlier today. This is intentionally incomplete--we're caching comment models to S3 on sync, but we don't (yet) expose the cache key to the user or restore the comment models from the cache if we lose access to storage. Looking forward to feedback, and will add tests if you all agree with the approach.