### PR TITLE
Restore required field general_comment.

### DIFF
--- a/regulations/tasks.py
+++ b/regulations/tasks.py
@@ -40,6 +40,7 @@ def submit_comment(self, body, files):
                 ('comment_on', settings.COMMENT_DOCUMENT_ID),
                 # TODO: Ensure this name is unique
                 ('uploadedFile', ('comment.pdf', comment)),
+                ('general_comment', 'See attached comment.pdf'),
             ]
             fields.extend(attachments)
             data = MultipartEncoder(fields)


### PR DESCRIPTION
From the regulations.gov docs:
On the Regulations.gov comment form, if a user does not enter any text
into the general_comment field and then selects a file to upload, we
will add the text "See attached file(s)" to the comment box. This helps
users avoid unnecessary warnings about required fields, and makes it
easier to identify file-only comments.