### PR TITLE
Tree nodes define comment accepting status

### DIFF
--- a/regulations/generator/html_builder.py
+++ b/regulations/generator/html_builder.py
@@ -224,5 +224,6 @@ class CFRChangeHTMLBuilder(CFRHTMLBuilder):
     def process_node(self, node, indexes=None):
         """Overrides with custom, additional processing"""
         super(CFRHTMLBuilder, self).process_node(node, indexes=indexes)
-        node['accepts_comments'] = True
-        node['comments_calledout'] = True
+        label_id = '-'.join(node['label'])
+        node['accepts_comments'] = label_id in self.diff_applier.diff
+        node['comments_calledout'] = label_id in self.diff_applier.diff

--- a/regulations/generator/html_builder.py
+++ b/regulations/generator/html_builder.py
@@ -212,3 +212,17 @@ class PreambleHTMLBuilder(HTMLBuilder):
             return label
         else:
             return 'FR #' + prefix[0]
+
+    def process_node(self, node, indexes=None):
+        """Overrides with custom, additional processing"""
+        super(PreambleHTMLBuilder, self).process_node(node, indexes=indexes)
+        node['accepts_comments'] = True
+        node['comments_calledout'] = bool(node.get('title'))
+
+
+class CFRChangeHTMLBuilder(CFRHTMLBuilder):
+    def process_node(self, node, indexes=None):
+        """Overrides with custom, additional processing"""
+        super(CFRHTMLBuilder, self).process_node(node, indexes=indexes)
+        node['accepts_comments'] = True
+        node['comments_calledout'] = True

--- a/regulations/generator/html_builder.py
+++ b/regulations/generator/html_builder.py
@@ -221,6 +221,8 @@ class PreambleHTMLBuilder(HTMLBuilder):
 
 
 class CFRChangeHTMLBuilder(CFRHTMLBuilder):
+    """Generated HTML specifically related to changing CFR data, as displayed
+    in a notice. This assumes self.diff_applier is set"""
     def process_node(self, node, indexes=None):
         """Overrides with custom, additional processing"""
         super(CFRHTMLBuilder, self).process_node(node, indexes=indexes)

--- a/regulations/generator/layers/diff_applier.py
+++ b/regulations/generator/layers/diff_applier.py
@@ -148,6 +148,7 @@ class DiffApplier(object):
         self.add_nodes_to_tree(original_tree, adds)
 
     def apply_diff_changes(self, original, diff_list):
+        """Account for modified text"""
         self.deconstruct_text(original)
         for d in diff_list:
             if d[0] == self.INSERT:
@@ -170,6 +171,8 @@ class DiffApplier(object):
         return self.get_text()
 
     def apply_diff(self, original, label, component='text'):
+        """Here we delete or add whole nodes in addition to passing to
+        `apply_diff_changes` when text has been modified"""
         if label in self.diff:
             if self.diff[label]['op'] == self.DELETED_OP:
                 return self.delete_all(original)

--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -4,7 +4,7 @@
 {% if node.header %}
 <div>
   <h{{ node.list_level|add:"+3" }} class="section-header">{{ node.header | safe }}</h{{ node.list_level|add:"+3" }}>
-  {% if use_comments %}
+  {% if node.accepts_comments %}
     <div
         class="activate-write"
         data-section="{{ node.full_id }}"
@@ -22,7 +22,8 @@
     {{node.marked_up|safe}}
 {% endif %}
 </p>
-{% if use_comments and not node.title %}
+{% comment %}@TODO use node.comments_calledout{% endcomment %}
+{% if node.accepts_comments and not node.title %}
   <div
       class="activate-write"
       data-section="{{ node.full_id }}"

--- a/regulations/tests/html_builder_test.py
+++ b/regulations/tests/html_builder_test.py
@@ -308,6 +308,14 @@ class CFRHTMLBuilderTest(TestCase):
 
 
 class PreambleHTMLBuilderTest(TestCase):
+    def setUp(self):
+        inline, par, sr = Mock(), Mock(), Mock()
+        inline.get_layer_pairs.return_value = []
+        par.apply_layers.side_effect = lambda x: x
+        sr.get_layer_pairs.return_value = []
+
+        self.builder = PreambleHTMLBuilder(inline, par, sr)
+
     def test_human_label(self):
         self.assertEqual(
             'FR #111_22',
@@ -326,3 +334,18 @@ class PreambleHTMLBuilderTest(TestCase):
                 'indexes': [2, 0, 1, 3, 2, 4]
             }),
         )
+
+    def test_accepts_comment(self):
+        """All of the preamble can be commented on. Some of it is called
+        out"""
+        node = {'label': ['ABCD_123', 'II', 'B', 'p4'], 'text': 'Something',
+                'node_type': 'preamble', 'children': []}
+        self.builder.process_node(node)
+        self.assertTrue(node.get('accepts_comments'))
+        self.assertFalse(node.get('comments_calledout'))
+
+        node = {'title': 'B. Has a title', 'label': ['ABCD_123', 'II', 'B'],
+                'text': 'Something', 'node_type': 'preamble', 'children': []}
+        self.builder.process_node(node)
+        self.assertTrue(node.get('accepts_comments'))
+        self.assertTrue(node.get('comments_calledout'))

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -9,7 +9,7 @@ from django.views.generic.base import View
 from regulations.generator.api_reader import ApiReader
 from regulations.generator.generator import LayerCreator
 from regulations.generator.html_builder import (
-    CFRHTMLBuilder, PreambleHTMLBuilder)
+    CFRChangeHTMLBuilder, PreambleHTMLBuilder)
 from regulations.generator.layers.utils import is_contained_in
 from regulations.generator.toc import fetch_toc
 from regulations.views import utils
@@ -150,7 +150,6 @@ class PreambleView(View):
         id_prefix = [doc_number, 'preamble']
         context = generate_html_tree(subtree, request, id_prefix=id_prefix)
 
-        context['use_comments'] = True
         template = context['node']['template_name']
 
         context = {
@@ -214,8 +213,6 @@ class CFRChangesView(View):
                 label_id=section,
             )
 
-        context['use_comments'] = True
-
         context = {
             'sub_context': context,
             'sub_template': 'regulations/cfr_changes.html',
@@ -259,7 +256,8 @@ class CFRChangesView(View):
         tree = ApiReader().regulation(label_id, versions.older)
         appliers = get_appliers(label_id, versions)
 
-        builder = CFRHTMLBuilder(*appliers, id_prefix=[str(doc_number), 'cfr'])
+        builder = CFRChangeHTMLBuilder(
+            *appliers, id_prefix=[str(doc_number), 'cfr'])
         builder.tree = tree
         builder.generate_html()
         return {'instructions': [a['instruction'] for a in relevant],


### PR DESCRIPTION
Currently, we have a bit of logic in the template (and views) which determine which nodes should accept comments and which shouldn't. This isn't super sustainable, as that logic is going to become more messy. This patch modifies the `HTMLBuilder`s to include whether or not a node can be commented on, including a quick use case: only CFR paragraphs _with changes_ accept comments.

Resolves eregs/notice-and-comment#121

Looks like
<img width="815" alt="screen shot 2016-04-11 at 2 03 24 pm" src="https://cloud.githubusercontent.com/assets/326918/14437483/61a4fb68-ffef-11e5-8628-2c1c37d4da76.png">
