### PR TITLE
Account for missing date in redirect

### DIFF
--- a/regulations/tests/views_redirect_tests.py
+++ b/regulations/tests/views_redirect_tests.py
@@ -66,6 +66,11 @@ class ViewsRedirectTest(TestCase):
             redirect.redirect_by_date_get(request, 'lablab')
             self.assertTrue(handle.called)
 
+        with patch('regulations.views.redirect.handle_generic_404') as handle:
+            request = RequestFactory().get('')
+            redirect.redirect_by_date_get(request, 'lablab')
+            self.assertTrue(handle.called)
+
     def test_diff_redirect_bad_version(self):
         request = RequestFactory().get('?new_version=A+Bad+Version')
         response = redirect.diff_redirect(request, 'lablab', 'verver')

--- a/regulations/views/redirect.py
+++ b/regulations/views/redirect.py
@@ -40,9 +40,9 @@ def redirect_by_date_get(request, label_id):
     """Handles date, etc. if they are part of the GET variable. We check for
     bad data here (as we can't rely on url regex)"""
     try:
-        year = abs(int(request.GET.get('year')))
-        month = abs(int(request.GET.get('month')))
-        day = abs(int(request.GET.get('day')))
+        year = abs(int(request.GET.get('year', '')))
+        month = abs(int(request.GET.get('month', '')))
+        day = abs(int(request.GET.get('day', '')))
 
         if year < 100:  # Assume two-digit years are for 2000
             year = 2000 + year


### PR DESCRIPTION
If a year/month/day were not present, we'd throw a TypeError due to `int`
trying to parse `None`. We catch ValueErrors already, so this patch modifies
the `get` so that it never returns `None`, only empty string.

Resolves #216