### PR TITLE
table of contents tab styles

### DIFF
--- a/regulations/static/regulations/css/less/module/drawer.less
+++ b/regulations/static/regulations/css/less/module/drawer.less
@@ -19,13 +19,20 @@ Universal drawer styles
 }
 
 .toc-head {
-    a:hover,
-    a:active,
-    a.current {
-        background-color: @light_field;
-        color: @pacific;
-        height: 34px;
-    }
+
+  a:link,
+  a:visited {
+    color: @black;
+    height: 33px;
+  }
+
+  a:hover,
+  a:active,
+  a.current {
+      background-color: @light_field;
+      color: @pacific;
+      height: 34px;
+  }
 }
 
 /*

--- a/regulations/static/regulations/css/less/module/drawer.less
+++ b/regulations/static/regulations/css/less/module/drawer.less
@@ -20,19 +20,25 @@ Universal drawer styles
 
 .toc-head {
 
+  transition: 0.1s;
+
   a:link,
   a:visited {
     color: @black;
     height: 33px;
   }
 
-  a:hover,
   a:active,
   a.current {
-      background-color: @light_field;
-      color: @pacific;
-      height: 34px;
+    background-color: @light_field;
+    color: @pacific;
+    height: 34px;
   }
+
+  a:hover:not(.current) {
+    height: 33px;
+  }
+
 }
 
 /*

--- a/regulations/static/regulations/css/less/module/drawer.less
+++ b/regulations/static/regulations/css/less/module/drawer.less
@@ -82,14 +82,13 @@ Drawer Links
 .toc-head {
     a:link,
     a:visited {
-        color: @dark_gray;
         text-decoration: none;
+        outline: none;
     }
 
     a:hover,
     a:active {
-            background-color: @light_field;
-            border-bottom: 1px solid @medium_gray;
+        background-color: @light_field;
     }
 }
 
@@ -159,8 +158,8 @@ currently these are TOC, History, and Search
     margin: 0;
     width: 56px;
     text-align: center;
+    color: @dark_gray;
     background-color: @light_field;
-    border-right: 1px solid @medium_gray;
     vertical-align: center;
 
     &.current {
@@ -170,7 +169,6 @@ currently these are TOC, History, and Search
 
     .close & {
         display: block;
-        *display: block;
         border-right: none;
         width: 40px;
     }
@@ -232,9 +230,9 @@ currently these are TOC, History, and Search
 .drawer-toggles li {
     display: inline-block;
     zoom: 1;
-    *display: inline;
     margin-left: -4px;
     border-right: 1px solid @medium_gray;
+    border-left: 1px solid @medium_gray;
 
     .close & {
         margin-left: 0;

--- a/regulations/static/regulations/css/less/module/drawer.less
+++ b/regulations/static/regulations/css/less/module/drawer.less
@@ -20,8 +20,11 @@ Universal drawer styles
 
 .toc-head {
     a:hover,
-    a:active {
+    a:active,
+    a.current {
         background-color: @light_field;
+        color: @pacific;
+        height: 34px;
     }
 }
 

--- a/regulations/templates/regulations/preamble-chrome.html
+++ b/regulations/templates/regulations/preamble-chrome.html
@@ -5,9 +5,7 @@
 
 {% block sidebar-icons %}
 <li>
-  <a href="#table-of-contents" id="menu-link" class="toc-nav-link current" title="Preamble Table of Contents">
-    <span class="menu-tab">Pre</span>
-  </a>
+  <a href="#table-of-contents" id="menu-link" class="toc-nav-link current" title="Preamble Table of Contents">Pre</a>
 </li>
 <li>
   <a href="#table-of-contents-secondary" id="table-of-contents-secondary-link" class="toc-nav-link" title="CFR Changes">CFR</a>
@@ -54,6 +52,7 @@
   <div id="table-of-contents-secondary" class="toc-container hidden">
     <div class="drawer-header">
       <h3 class="toc-type">Table of Contents</h3>
+      <h5 class="toc-subheader">Amendments to the CFR</h5>
     </div>
     <nav id="cfr-toc" class="regulation-nav drawer-content" role="navigation">
       <ol>


### PR DESCRIPTION
fixes #210 

Adds subheader to CFR tab.

Notice & Comment specific styles added to notice-and-comment

![screen shot 2016-04-11 at 4 00 06 pm](https://cloud.githubusercontent.com/assets/776987/14442432/5a158b6e-ffff-11e5-8122-7c0d630c7a66.png)
