### PR TITLE
Fix write tab click behavior

### DIFF
--- a/regulations/static/regulations/js/source/views/main/preamble-view.js
+++ b/regulations/static/regulations/js/source/views/main/preamble-view.js
@@ -70,9 +70,9 @@ var PreambleView = ChildView.extend({
     var $section = $('#' + this.currentSectionId);
 
     this.write(
-      this.currentSectionId,
+      $section.find('.activate-write').data('section'),
       $section.find('.activate-write').data('label'),
-      $section.find('[data-permalink-section]')
+      $section
     );
   },
 


### PR DESCRIPTION
Corrected an error in which sometimes clicking on the Write tab would result in a missing preamble excerpt on the Write a Comment section. It usually happened when clicking on the Write tab when the page has been scrolled to a particular section (and the url has updated as a result).

Fixed by passing the correct section reference through the function that handles clicks to the Write tab.