### PR TITLE
Fix Comment Edit in Index and Review

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -427,16 +427,14 @@ a.comment-index-review {
 
 
 @media only screen and ( min-width: 780px ) {
-  .preamble-wrapper,
-  .comment-review-wrapper {
+  .preamble-wrapper {
     margin-right: 5%;
     padding-left: 35px;
   }
 }
 
 @media only screen and ( min-width: 1100px ) {
-  .preamble-wrapper,
-  .comment-review-wrapper {
+  .preamble-wrapper {
     margin-right: 5%;
     padding-left: 35px;
   }

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -9,7 +9,7 @@ comment.less contains styles related to commenting on sections
   padding: 0 0 0 15px;
 
   li {
-    h2, h3, h4, h5, p {
+    h2, h3, h4, h5, h6, p {
       width: 70%;
     }
   }

--- a/regulations/static/regulations/js/source/views/comment/comment-index-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-index-view.js
@@ -37,6 +37,7 @@ module.exports = Backbone.CommentIndexView = Backbone.View.extend({
 
   render: function() {
     var commentData = comments.toJSON({docId: this.docId});
+
     var html = this.template({comments: commentData});
     this.$index.html(html);
 
@@ -50,6 +51,7 @@ module.exports = Backbone.CommentIndexView = Backbone.View.extend({
   editComment: function(e) {
     var options = _.extend({mode: 'write'}, getOptions(e.target));
     var type = options.section.split('-')[1];
+
     DrawerEvents.trigger('section:open', options.section);
     DrawerEvents.trigger('pane:change', type === 'preamble' ? 'table-of-contents' : 'table-of-contents-secondary');
     MainEvents.trigger('section:open', options.section, options, 'preamble-section');

--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -51,7 +51,7 @@ var CommentReviewView = Backbone.View.extend({
     var section = $(e.target).closest('li').data('section');
     var options = {id: section, section: section, mode: 'write'};
 
-    $('#content-body').removeClass('comment-review-wrapper');
+    $('#content-body').removeClass('comment-review-wrapper').addClass('preamble-wrapper');
 
     MainEvents.trigger('section:open', section, options, 'preamble-section');
     CommentEvents.trigger('comment:writeTabOpen');

--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -42,7 +42,7 @@ var CommentReviewView = Backbone.View.extend({
     var section = this.docId + '-preamble-' + this.docId + '-I';
     var options = {id: section, section: section, mode: 'read'};
 
-    $('#content-body').removeClass('comment-review-wrapper').addClass('preamble-wrapper');
+    $('#content-body').removeClass('comment-review-wrapper');
 
     MainEvents.trigger('section:open', section, options, 'preamble-section');
   },
@@ -51,7 +51,7 @@ var CommentReviewView = Backbone.View.extend({
     var section = $(e.target).closest('li').data('section');
     var options = {id: section, section: section, mode: 'write'};
 
-    $('#content-body').removeClass('comment-review-wrapper').addClass('preamble-wrapper');
+    $('#content-body').removeClass('comment-review-wrapper');
 
     MainEvents.trigger('section:open', section, options, 'preamble-section');
     CommentEvents.trigger('comment:writeTabOpen');

--- a/regulations/static/regulations/js/source/views/main/preamble-view.js
+++ b/regulations/static/regulations/js/source/views/main/preamble-view.js
@@ -111,7 +111,8 @@ var PreambleView = ChildView.extend({
     });
 
     if (this.options.mode === 'write') {
-      var $parent = $('#' + this.options.section).find('[data-permalink-section]');
+      var $parent = $('#' + this.options.scrollToId);
+
       this.write(this.options.section, this.options.label, $parent);
     } else {
       this.handleRead();

--- a/regulations/templates/regulations/comment-review-chrome.html
+++ b/regulations/templates/regulations/comment-review-chrome.html
@@ -45,7 +45,7 @@
 {% block chrome-content %}
 
 <main role="main">
-  <div id="content-body" class="main-content comment-review-wrapper">
+  <div id="content-body" class="main-content preamble-wrapper comment-review-wrapper">
     <section id="comment-review" data-page-type="comment-review" data-doc-id="{{doc_number}}">
       <h2>Review your full comment</h2>
       <h3>You are submitting an official comment to Regulations.gov.</h3>


### PR DESCRIPTION
* Fixed a bug in which comment ids weren't passed correctly in write mode rendering, causing comment write excerpts to not show up when trying to edit the comment in the index section or review page.
* Added `preamble-wrapper` class when going back to write mode from review page so the page width updates accordingly.
* Make sure `h6` headers in preamble don't extend into write a comment links.