### PR TITLE
[wip] Highlight preamble toc sections as appropriate.

### DIFF
--- a/regulations/generator/html_builder.py
+++ b/regulations/generator/html_builder.py
@@ -218,6 +218,9 @@ class PreambleHTMLBuilder(HTMLBuilder):
         super(PreambleHTMLBuilder, self).process_node(node, indexes=indexes)
         node['accepts_comments'] = True
         node['comments_calledout'] = bool(node.get('title'))
+        not_markerless = lambda l: not node_types.MARKERLESS_REGEX.match(l)
+        markers = takewhile(not_markerless, node['label'][:4])
+        node['toc_id'] = '-'.join(self.id_prefix + list(markers))
 
 
 class CFRChangeHTMLBuilder(CFRHTMLBuilder):

--- a/regulations/static/regulations/js/source/helpers.js
+++ b/regulations/static/regulations/js/source/helpers.js
@@ -161,8 +161,7 @@ module.exports = {
 
         if (id.indexOf('-') !== -1) {
             parts = id.split('-');
-        }
-        else {
+        } else {
             return id;
         }
 
@@ -300,7 +299,6 @@ module.exports = {
      *   hash: '2016_02749-I-A'
      * }
      * @example
-     * // Returns ['preamble', '2016_02749', 'cfr_changes', '478-32-a']
      * parsePreambleId('2016_02749-cfr-478-32-a-1')
      * {
      *    docId: '2016_02749',

--- a/regulations/static/regulations/js/source/helpers.js
+++ b/regulations/static/regulations/js/source/helpers.js
@@ -320,6 +320,7 @@ module.exports = {
       }
       return {
         path: path,
+        type: type,
         hash: parts.join('-'),
         docId: docId
       };

--- a/regulations/static/regulations/js/source/helpers.js
+++ b/regulations/static/regulations/js/source/helpers.js
@@ -311,17 +311,21 @@ module.exports = {
       var docId = parts.shift();
       var type = parts.shift();
       var path = ['preamble', docId];
+      var section;
       if (type === 'preamble') {
         // Note: Document ID appears twice in preamble IDs
         // TODO: Standardize IDs and drop the `slice`
         path = path.concat(parts.slice(1, 2));
+        section = [docId].concat(parts.slice(1, 2));
       } else if (type === 'cfr') {
         path = path.concat(['cfr_changes', parts.join('-')]);
+        section = parts.slice(0, 2);
       }
       return {
         path: path,
         type: type,
         hash: parts.join('-'),
+        section: section,
         docId: docId
       };
     }

--- a/regulations/static/regulations/js/source/views/comment/comment-index-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-index-view.js
@@ -14,6 +14,7 @@ function getOptions(elm) {
   var $elm = $(elm).closest('.comment-index-item');
   return {
     section: $elm.data('comment-section'),
+    tocId: $elm.data('comment-toc-section'),
     label: $elm.data('comment-label')
   };
 }
@@ -50,7 +51,7 @@ module.exports = Backbone.CommentIndexView = Backbone.View.extend({
   editComment: function(e) {
     var options = _.extend({mode: 'write'}, getOptions(e.target));
     var type = options.section.split('-')[1];
-    DrawerEvents.trigger('section:open', options.section);
+    DrawerEvents.trigger('section:open', options.tocId);
     DrawerEvents.trigger('pane:change', type === 'preamble' ? 'table-of-contents' : 'table-of-contents-secondary');
     MainEvents.trigger('section:open', options.section, options, 'preamble-section');
     CommentEvents.trigger('comment:writeTabOpen');

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -60,23 +60,23 @@ var CommentView = Backbone.View.extend({
     this.listenTo(CommentEvents, 'comment:target', this.target);
     this.listenTo(CommentEvents, 'attachment:remove', this.clearAttachment);
 
-    this.setSection(options.section, options.label);
+    this.setSection(options.section, options.tocId, options.label);
   },
 
-  setSection: function(section, label, blank) {
+  setSection: function(section, tocId, label, blank) {
     if (this.model) {
       this.stopListening(this.model);
     }
-    var options = {id: section, label: label, docId: this.options.docId};
+    var options = {id: section, tocId: tocId, label: label, docId: this.options.docId};
     this.model = blank ?
       new CommentModel(options) :
       comments.get(section) || new CommentModel(options);
-    this.listenTo(this.model, 'destroy', this.setSection.bind(this, section, label, true));
+    this.listenTo(this.model, 'destroy', this.setSection.bind(this, section, tocId, label, true));
     this.render();
   },
 
   target: function(options) {
-    this.setSection(options.section, options.label);
+    this.setSection(options.section, options.tocId, options.label);
     this.$context.empty();
     if (options.$parent) {
       this.$context.append(options.$parent);

--- a/regulations/static/regulations/js/source/views/drawer/toc-view.js
+++ b/regulations/static/regulations/js/source/views/drawer/toc-view.js
@@ -41,7 +41,7 @@ var TOCView = Backbone.View.extend({
     setActive: function(id) {
         var newActiveLink, subpart;
 
-        newActiveLink = this.$el.find('a[data-section-id="' + Helpers.findBaseSection(id) + '"]');
+        newActiveLink = this.$el.find('a[data-section-id="' + id + '"]');
 
         this.$el.find('.current').removeClass('current');
         newActiveLink.addClass('current');

--- a/regulations/static/regulations/js/source/views/drawer/toc-view.js
+++ b/regulations/static/regulations/js/source/views/drawer/toc-view.js
@@ -38,10 +38,10 @@ var TOCView = Backbone.View.extend({
     },
 
     // update active classes, find new active based on the reg entity id in the anchor
-    setActive: function(id) {
+    setActive: function(tocId) {
         var newActiveLink, subpart;
 
-        newActiveLink = this.$el.find('a[data-section-id="' + id + '"]');
+        newActiveLink = this.$el.find('a[data-section-id="' + tocId + '"]');
 
         this.$el.find('.current').removeClass('current');
         newActiveLink.addClass('current');

--- a/regulations/static/regulations/js/source/views/main/child-view.js
+++ b/regulations/static/regulations/js/source/views/main/child-view.js
@@ -105,23 +105,21 @@ var ChildView = Backbone.View.extend({
                 if (_.isEmpty(this.activeSection) || (this.activeSection !== this.$sections[i].id)) {
                     this.activeSection = this.$sections[i][0].id;
                     this.$activeSection = $(this.$sections[i][0]);
-                    if (this.$activeSection.is(':visible')) {
-                        // **Event** trigger active section change
-                        HeaderEvents.trigger('section:open', this.activeSection);
-                        DrawerEvents.trigger('section:open', this.$activeSection.data('toc-id'));
-                        MainEvents.trigger('paragraph:active', this.activeSection);
+                    // **Event** trigger active section change
+                    HeaderEvents.trigger('section:open', this.activeSection);
+                    DrawerEvents.trigger('section:open', this.$activeSection.data('toc-id') || this.id);
+                    MainEvents.trigger('paragraph:active', this.activeSection);
 
-                        if (typeof window.history !== 'undefined' && typeof window.history.replaceState !== 'undefined') {
-                            // update hash in url
-                            window.history.replaceState(
-                                null,
-                                null,
-                                window.location.origin + window.location.pathname + window.location.search + '#' + this.activeSection
-                            );
-                        }
-
-                        return;
+                    if (typeof window.history !== 'undefined' && typeof window.history.replaceState !== 'undefined') {
+                        // update hash in url
+                        window.history.replaceState(
+                            null,
+                            null,
+                            window.location.origin + window.location.pathname + window.location.search + '#' + this.activeSection
+                        );
                     }
+
+                    return;
                 }
             }
         }

--- a/regulations/static/regulations/js/source/views/main/child-view.js
+++ b/regulations/static/regulations/js/source/views/main/child-view.js
@@ -78,8 +78,8 @@ var ChildView = Backbone.View.extend({
         this.updateWayfinding();
         this.loadImages();
         // TODO: What is this for?
-        // HeaderEvents.trigger('section:open', this.id);
-        // DrawerEvents.trigger('section:open', this.id);
+        HeaderEvents.trigger('section:open', this.id);
+        DrawerEvents.trigger('section:open', this.id);
     },
 
     changeFocus: function(id) {

--- a/regulations/static/regulations/js/source/views/main/child-view.js
+++ b/regulations/static/regulations/js/source/views/main/child-view.js
@@ -77,8 +77,9 @@ var ChildView = Backbone.View.extend({
     render: function() {
         this.updateWayfinding();
         this.loadImages();
-        HeaderEvents.trigger('section:open', this.id);
-        DrawerEvents.trigger('section:open', this.id);
+        // TODO: What is this for?
+        // HeaderEvents.trigger('section:open', this.id);
+        // DrawerEvents.trigger('section:open', this.id);
     },
 
     changeFocus: function(id) {
@@ -104,20 +105,23 @@ var ChildView = Backbone.View.extend({
                 if (_.isEmpty(this.activeSection) || (this.activeSection !== this.$sections[i].id)) {
                     this.activeSection = this.$sections[i][0].id;
                     this.$activeSection = $(this.$sections[i][0]);
-                    // **Event** trigger active section change
-                    HeaderEvents.trigger('section:open', this.activeSection);
-                    MainEvents.trigger('paragraph:active', this.activeSection);
+                    if (this.$activeSection.is(':visible')) {
+                        // **Event** trigger active section change
+                        HeaderEvents.trigger('section:open', this.activeSection);
+                        DrawerEvents.trigger('section:open', this.$activeSection.data('toc-id'));
+                        MainEvents.trigger('paragraph:active', this.activeSection);
 
-                    if (typeof window.history !== 'undefined' && typeof window.history.replaceState !== 'undefined') {
-                        // update hash in url
-                        window.history.replaceState(
-                            null,
-                            null,
-                            window.location.origin + window.location.pathname + window.location.search + '#' + this.activeSection
-                        );
+                        if (typeof window.history !== 'undefined' && typeof window.history.replaceState !== 'undefined') {
+                            // update hash in url
+                            window.history.replaceState(
+                                null,
+                                null,
+                                window.location.origin + window.location.pathname + window.location.search + '#' + this.activeSection
+                            );
+                        }
+
+                        return;
                     }
-
-                    return;
                 }
             }
         }

--- a/regulations/static/regulations/js/source/views/main/preamble-view.js
+++ b/regulations/static/regulations/js/source/views/main/preamble-view.js
@@ -25,10 +25,8 @@ var PreambleView = ChildView.extend({
     this.options = options;
 
     var parsed = helpers.parsePreambleId(this.options.id);
-    var type = parsed.path[0];
 
-    this.tocId = null;
-    this.id = [parsed.docId].concat(parsed.path).join('-');
+    this.id = [parsed.docId, parsed.type, parsed.hash].join('-');
     this.options.scrollToId = parsed.hash;
     this.url = parsed.path.join('/');
 
@@ -43,10 +41,16 @@ var PreambleView = ChildView.extend({
     this.listenTo(MainEvents, 'paragraph:active', this.handleParagraphActive);
 
     CommentEvents.trigger('comment:readTabOpen');
-    DrawerEvents.trigger('pane:init', type === 'preamble' ? 'table-of-contents' : 'table-of-contents-secondary');
+    DrawerEvents.trigger(
+      'pane:init',
+      parsed.type === 'preamble' ?
+        'table-of-contents' :
+        'table-of-contents-secondary'
+    );
   },
 
   handleRead: function() {
+    this.mode = 'read';
     this.$write.hide();
     this.$read.show();
   },
@@ -81,6 +85,7 @@ var PreambleView = ChildView.extend({
   },
 
   write: function(section, tocId, label, $parent) {
+    this.mode = 'write';
     $parent = $parent.clone();
     $parent.find('.activate-write').remove();
     CommentEvents.trigger('comment:target', {
@@ -96,6 +101,7 @@ var PreambleView = ChildView.extend({
   render: function() {
     ChildView.prototype.render.apply(this, arguments);
 
+    this.mode = 'read';
     this.$read = this.$el.find('#preamble-read');
     this.$write = this.$el.find('#preamble-write');
 
@@ -127,6 +133,15 @@ var PreambleView = ChildView.extend({
     this.commentView.remove();
     this.commentIndex.remove();
     Backbone.View.prototype.remove.call(this);
+  },
+
+  /**
+   * Update section in viewport if in read mode.
+   */
+  checkActiveSection: function() {
+    if (this.mode === 'read') {
+      ChildView.prototype.checkActiveSection.call(this);
+    }
   }
 });
 

--- a/regulations/static/regulations/js/source/views/main/preamble-view.js
+++ b/regulations/static/regulations/js/source/views/main/preamble-view.js
@@ -26,7 +26,7 @@ var PreambleView = ChildView.extend({
 
     var parsed = helpers.parsePreambleId(this.options.id);
 
-    this.id = [parsed.docId, parsed.type, parsed.hash].join('-');
+    this.id = [].concat(parsed.docId, parsed.type, parsed.section).join('-');
     this.options.scrollToId = parsed.hash;
     this.url = parsed.path.join('/');
 

--- a/regulations/static/regulations/js/source/views/main/preamble-view.js
+++ b/regulations/static/regulations/js/source/views/main/preamble-view.js
@@ -27,6 +27,7 @@ var PreambleView = ChildView.extend({
     var parsed = helpers.parsePreambleId(this.options.id);
     var type = parsed.path[0];
 
+    this.tocId = null;
     this.id = [parsed.docId].concat(parsed.path).join('-');
     this.options.scrollToId = parsed.hash;
     this.url = parsed.path.join('/');
@@ -57,10 +58,12 @@ var PreambleView = ChildView.extend({
 
   handleWriteLink: function(e) {
     var $target = $(e.target);
+    var $section = $target.closest('[data-permalink-section]');
     this.write(
       $target.data('section'),
+      $section.data('toc-id'),
       $target.data('label'),
-      $target.closest('[data-permalink-section]')
+      $section
     );
 
     CommentEvents.trigger('comment:writeTabOpen');
@@ -71,16 +74,18 @@ var PreambleView = ChildView.extend({
 
     this.write(
       $section.find('.activate-write').data('section'),
+      $section.data('toc-id'),
       $section.find('.activate-write').data('label'),
       $section
     );
   },
 
-  write: function(section, label, $parent) {
+  write: function(section, tocId, label, $parent) {
     $parent = $parent.clone();
     $parent.find('.activate-write').remove();
     CommentEvents.trigger('comment:target', {
       section: section,
+      tocId: tocId,
       label: label,
       $parent: $parent
     });
@@ -112,7 +117,7 @@ var PreambleView = ChildView.extend({
 
     if (this.options.mode === 'write') {
       var $parent = $('#' + this.options.section).find('[data-permalink-section]');
-      this.write(this.options.section, this.options.label, $parent);
+      this.write(this.options.section, this.options.tocId, this.options.label, $parent);
     } else {
       this.handleRead();
     }

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -40,6 +40,7 @@
     <li
         class="comment-index-item group"
         data-comment-section="<%= comment.id %>"
+        data-comment-toc-section="<%= comment.tocId %>"
         data-comment-label="<%= comment.label %>">
       <div class="comment-index-section"><%= comment.label %></div>
       <div class="comment-index-modify">

--- a/regulations/templates/regulations/tree/default.html
+++ b/regulations/templates/regulations/tree/default.html
@@ -4,6 +4,7 @@
 
 <li
     {% if node.marker %}marker-type="{{node.marker}}"{% endif %}
+    {% if node.toc_id %}data-toc-id="{{node.toc_id}}"{% endif %}
     {% if not inline %}id="{{node.markup_id}}" data-permalink-section{% endif %}
     {% if node.interp %}data-interp-id="{{node.interp.markup_id}}"{% endif %}
 >


### PR DESCRIPTION
This is incomplete (still need to implement reg sections and cfr changes) but works for preambles. I'm submitting not necessarily because I think this is the right way to go, but to illustrate how many parts of the code have to change to add a single field (in this case, toc id) to comments. I'm hoping to use this sketch as a starting point for discussing how to make some of the js less brittle.

cc @cmc333333 @xtine 