### PR TITLE
top of table of contents now sticky

### DIFF
--- a/regulations/static/regulations/css/less/module/drawer-content.less
+++ b/regulations/static/regulations/css/less/module/drawer-content.less
@@ -5,6 +5,8 @@ This contains all of the styles specific to the TOC
 */
 .regulation-nav {
 
+    padding-top: 70px;
+
     ol {
         margin: 0;
         padding: 5px 0 0 0;

--- a/regulations/static/regulations/css/less/module/drawer-content.less
+++ b/regulations/static/regulations/css/less/module/drawer-content.less
@@ -5,7 +5,7 @@ This contains all of the styles specific to the TOC
 */
 .regulation-nav {
 
-    padding-top: 70px;
+    padding-top: 72px;
 
     ol {
         margin: 0;

--- a/regulations/static/regulations/css/less/module/drawer.less
+++ b/regulations/static/regulations/css/less/module/drawer.less
@@ -58,6 +58,8 @@ Panel Header
 
 .drawer-header {
 
+  position: fixed;
+
   .toc-type, .toc-subheader {
     position: relative;
     margin: 0;


### PR DESCRIPTION
![screen shot 2016-04-13 at 4 18 56 pm](https://cloud.githubusercontent.com/assets/776987/14509733/7376e770-0193-11e6-9d21-1a04449586c5.png)

^ the top of the table of contents would go away when you scroll

![screen shot 2016-04-13 at 4 19 35 pm](https://cloud.githubusercontent.com/assets/776987/14509747/8dbabbb6-0193-11e6-9553-ae39d55da3d1.png)

^ now it doesn't