### PR TITLE
Preamble header padding fix

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -14,11 +14,6 @@ comment.less contains styles related to commenting on sections
     }
   }
 
-  // neutralize padding for write comment link placing
-  .level-1 > li {
-    padding-top: 0;
-  }
-
   // for paragraphs, only show write comment link when hovered
   div:hover {
     > p + .activate-write {

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -15,7 +15,7 @@ comment.less contains styles related to commenting on sections
   }
 
   // for paragraphs, only show write comment link when hovered
-  div:hover {
+  .node:hover {
     > p + .activate-write {
       top: 15px;
       display: block;
@@ -61,7 +61,7 @@ comment.less contains styles related to commenting on sections
 }
 
 #preamble-write,
-#preamble-read li > div {
+#preamble-read .node {
   position: relative;
 }
 

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -20,7 +20,7 @@ comment.less contains styles related to commenting on sections
   }
 
   // for paragraphs, only show write comment link when hovered
-  li:hover {
+  div:hover {
     > p + .activate-write {
       top: 15px;
       display: block;
@@ -66,7 +66,7 @@ comment.less contains styles related to commenting on sections
 }
 
 #preamble-write,
-#preamble-read li {
+#preamble-read li > div {
   position: relative;
 }
 

--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -2,7 +2,7 @@
     Template for inner paragraphs of a reg section
 {% endcomment %}
 {% if node.header %}
-<div>
+<div class="node">
   <h{{ node.list_level|add:"+3" }} class="section-header">{{ node.header | safe }}</h{{ node.list_level|add:"+3" }}>
   {% if node.accepts_comments %}
     <div
@@ -14,7 +14,7 @@
 </div>
 {% endif %}
 
-<div>
+<div class="node">
 {%if node.marked_up %}
 <p {% if node.is_collapsed %}class="collapsed"{% endif %}>
 {% if node.node_type == "appendix" %}

--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -14,6 +14,7 @@
 </div>
 {% endif %}
 
+<div>
 {%if node.marked_up %}
 <p {% if node.is_collapsed %}class="collapsed"{% endif %}>
 {% if node.node_type == "appendix" %}
@@ -31,6 +32,7 @@
     + Write a comment about {{ node.human_label }}</div>
 {% endif %}
 {% endif %}
+</div>
 
 {% if node.children %}
 <ol class="level-{{node.list_level|add:1}}">

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -1,6 +1,6 @@
 {% load macros render_nested %}
 
-<section id="{{full_id}}" data-page-type="preamble-section" data-doc-id="{{doc_number}}">
+<section id="{{full_id}}" class="reg-section" data-page-type="preamble-section" data-doc-id="{{doc_number}}">
   <ul id="preamble-read">
     {% render_nested template=sub_template context=sub_context %}
   </ul>


### PR DESCRIPTION
* Add `.reg-section` class to preamble sections for header offset border/margin hack for anchor tags to navigate correctly. Fixes eregs/notice-and-comment#132
* Preamble list items are no longer positioned relatively (nested divs are instead) to prevent issues with other pages.