### PR TITLE
Footnotes in Preamble

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -420,6 +420,11 @@ a.comment-index-review {
   }
 }
 
+.preamble-wrapper {
+  .footnote-box {
+    width: 70%;
+  }
+}
 
 @media only screen and ( min-width: 780px ) {
   .preamble-wrapper {

--- a/regulations/templates/regulations/footnotes.html
+++ b/regulations/templates/regulations/footnotes.html
@@ -1,0 +1,15 @@
+  {% if sub_context.node.footnotes %}
+  <div class="footnote-box">
+      <h5>Footnotes</h5>
+      <ul class="footnotes">
+          {% for footnote in sub_context.node.footnotes %}
+          <li id="footnote-{{footnote.ref}}">
+              <span class="reference-num">{{footnote.ref}}.</span>
+              <p>
+                  {{footnote.note}}
+              </p>
+          </li>
+          {% endfor %}
+      </ul>
+  </div>
+  {% endif %}

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -5,21 +5,7 @@
     {% render_nested template=sub_template context=sub_context %}
   </ul>
 
-  {% if sub_context.node.footnotes %}
-  <div class="footnote-box">
-      <h5>Footnotes</h5>
-      <ul class="footnotes">
-          {% for footnote in sub_context.node.footnotes %}
-          <li id="footnote-{{footnote.ref}}">
-              <span class="reference-num">{{footnote.ref}}.</span>
-              <p>
-                  {{footnote.note}}
-              </p>
-          </li>
-          {% endfor %}
-      </ul>
-  </div>
-  {% endif %}
+  {% include "regulations/footnotes.html" %}
 
   <div id="preamble-write">
     <div class="comment-wrapper">

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -5,6 +5,22 @@
     {% render_nested template=sub_template context=sub_context %}
   </ul>
 
+  {% if sub_context.node.footnotes %}
+  <div class="footnote-box">
+      <h5>Footnotes</h5>
+      <ul class="footnotes">
+          {% for footnote in sub_context.node.footnotes %}
+          <li id="footnote-{{footnote.ref}}">
+              <span class="reference-num">{{footnote.ref}}.</span>
+              <p>
+                  {{footnote.note}}
+              </p>
+          </li>
+          {% endfor %}
+      </ul>
+  </div>
+  {% endif %}
+
   <div id="preamble-write">
     <div class="comment-wrapper">
       <div class="comment">

--- a/regulations/templates/regulations/regulation_text.html
+++ b/regulations/templates/regulations/regulation_text.html
@@ -6,8 +6,8 @@
 <section id="{{c.markup_id}}" class="reg-section section-focus" tabindex="0" data-permalink-section data-base-version="{{version}}" data-page-type="{{markup_page_type}}" {% if newer_version %}data-newer-version="{{newer_version}}"{% endif %}>
     <h3 class="section-title" tabindex="0"> {{c.header|safe}} </h3>
         {% if c.marked_up %}
-        <p> 
-        {{c.marked_up|safe}} 
+        <p>
+        {{c.marked_up|safe}}
         </p>
         {% endif %}
 
@@ -24,20 +24,8 @@
                 {% include "regulations/slide-down-interp.html" %}
             {% endwith %}
         {% endif %}
-        {% if c.footnotes %}
-        <div class="footnote-box">
-            <h5>Footnotes</h5>
-            <ul class="footnotes">
-                {% for footnote in c.footnotes %}
-                <li id="footnote-{{footnote.ref}}">
-                    <span class="reference-num">{{footnote.ref}}.</span>
-                    <p>
-                        {{footnote.note}}
-                    </p>
-                </li>
-                {% endfor %}
-            </ul>
-        </div>
-        {% endif %}
+
+    {% include "regulations/footnotes.html" %}
+
 </section>
 {% endif %}


### PR DESCRIPTION
Showing footnotes box in preamble. Has the default style but will override in N&C repo.

<img width="1165" alt="screen shot 2016-04-13 at 6 49 57 pm" src="https://cloud.githubusercontent.com/assets/24054/14513878/c2767b64-01a8-11e6-90ef-84bcd1e0d356.png">
