### PR TITLE
Responsive mobile view

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -271,7 +271,7 @@ a.comment-index-review {
   }
 
   .comment-content {
-    width: 480px;
+    max-width: 480px;
   }
 
   .edit-comment {
@@ -292,7 +292,7 @@ a.comment-index-review {
 
   .comment-attachments {
     margin-top: 5px;
-    width: 480px;
+    max-width: 480px;
 
     ul {
       background: @grey;
@@ -333,7 +333,7 @@ a.comment-index-review {
       font-size: 18px;
       line-height: 18px;
       text-transform: inherit;
-      width: 425px;
+      max-width: 425px;
 
       &:hover {
         cursor: pointer;
@@ -357,7 +357,7 @@ a.comment-index-review {
 
   .additional-info {
     padding: 0 0 10px 0;
-    width: 535px;
+    max-width: 535px;
 
     h4 {
       margin-bottom: 0.75em;
@@ -394,7 +394,7 @@ a.comment-index-review {
     border-top: 1px solid @text_area_border;
     padding: 10px 0 0;
     margin: 15px 0 25px 0;
-    width: 535px;
+    max-width: 535px;
 
     .required {
       color: @red_orange;
@@ -420,6 +420,65 @@ a.comment-index-review {
   }
 }
 
+@media only screen and ( max-width: 480px ) {
+
+  .preamble-header {
+    z-index: -1;
+
+    > span {
+      display: none;
+    }
+
+    .read-proposal,
+    .write-comment {
+      font-size: 13px;
+      width: 140px !important;
+    }
+  }
+
+  .activate-write {
+    padding: 5px 0;
+    position: relative;
+    right: 0;
+    top: 0;
+    width: auto;
+
+    &:hover {
+      color: #4A90E2;
+    }
+  }
+
+  #preamble-read {
+    li {
+      h2, h3, h4, h5, h6, p {
+        width: 100%;
+      }
+    }
+    p + .activate-write {
+      display: block;
+    }
+  }
+
+  #preamble-write {
+    padding-left: 0;
+    width: 100%;
+
+    .comment-index {
+      position: relative;
+      right: 0;
+      top: 0;
+      width: 100%;
+    }
+  }
+
+  #comment-review {
+    .edit-comment {
+      position: relative;
+      right: 0;
+      top: 5px;
+    }
+  }
+}
 
 @media only screen and ( min-width: 780px ) {
   .preamble-wrapper {


### PR DESCRIPTION
Quick pass at making N&C work nicer on a mobile width/screen.

<img width="304" alt="screen shot 2016-04-13 at 8 25 29 pm" src="https://cloud.githubusercontent.com/assets/24054/14515339/6aa0684c-01b6-11e6-9acc-e1e5b1a4604d.png">
<img width="312" alt="screen shot 2016-04-13 at 8 26 07 pm" src="https://cloud.githubusercontent.com/assets/24054/14515338/6a9f9f66-01b6-11e6-8748-7839b2b0a281.png">
<img width="308" alt="screen shot 2016-04-13 at 8 26 12 pm" src="https://cloud.githubusercontent.com/assets/24054/14515336/6a9f025e-01b6-11e6-9217-7ed12d13a3b6.png">
<img width="307" alt="screen shot 2016-04-13 at 8 26 20 pm" src="https://cloud.githubusercontent.com/assets/24054/14515337/6a9f27a2-01b6-11e6-9c23-ebe6b18ac372.png">

eregs/notice-and-comment#145