### PR TITLE
making table of contents tab compatible with old cfr viewer

### DIFF
--- a/regulations/static/regulations/css/less/module/drawer-content.less
+++ b/regulations/static/regulations/css/less/module/drawer-content.less
@@ -5,7 +5,11 @@ This contains all of the styles specific to the TOC
 */
 .regulation-nav {
 
-    padding-top: 72px;
+    padding-top: 32px;
+
+    &.preamble-nav {
+      padding-top: 72px;
+    }
 
     ol {
         margin: 0;

--- a/regulations/static/regulations/css/less/module/drawer.less
+++ b/regulations/static/regulations/css/less/module/drawer.less
@@ -59,24 +59,24 @@ Panel Header
 .drawer-header {
 
   position: fixed;
+  background-color: @bg_gray;
+  border-right: 2px solid @medium_gray;
+  border-bottom: 1px solid @medium_gray;
 
   .toc-type, .toc-subheader {
     position: relative;
     margin: 0;
-    width: 240px;
-    height: 32px;
+    width: 238px;
+    height: 40px;
     line-height: 40px;
-    background-color: @bg_gray;
-    border-right: 2px solid @medium_gray;
     border-bottom: none;
     z-index: 100;
     padding: 0 15px;
   }
 
   .toc-subheader {
-    line-height: 20px;
-    height: 30px;
-    border-bottom: 1px solid @medium_gray;
+    line-height: 5px;
+    height: 22px;
   }
 
   h3 {

--- a/regulations/templates/regulations/preamble-chrome.html
+++ b/regulations/templates/regulations/preamble-chrome.html
@@ -25,7 +25,7 @@
       <h3 class="toc-type">Table of Contents</h3>
       <h5 class="toc-subheader">Preamble</h5>
     </div><!-- /.drawer-header -->
-    <nav id="toc" class="regulation-nav drawer-content" role="navigation">
+    <nav id="toc" class="regulation-nav drawer-content preamble-nav" role="navigation">
       {% include "regulations/toc-preamble.html" %}
     </nav>
   </div>
@@ -35,7 +35,7 @@
       <h3 class="toc-type">Table of Contents</h3>
       <h5 class="toc-subheader">Amendments to the CFR</h5>
     </div>
-    <nav id="cfr-toc" class="regulation-nav drawer-content" role="navigation">
+    <nav id="cfr-toc" class="regulation-nav drawer-content preamble-nav" role="navigation">
       <ol>
         {% for cfr_part_toc in cfr_change_toc %}
           <li>


### PR DESCRIPTION
fix for eregs/notice-and-comment#147

The default padding is now the one that works for the old CFR viewer then there is an override for preamble to account for the subheader it has. 

Also, border styles removed from the headers and onto the header block itself.

Colors will be messed up unless you test at the same time as the PR in eregs/notice-and-comment#149

![screen shot 2016-04-14 at 1 15 55 pm](https://cloud.githubusercontent.com/assets/776987/14538786/0a0bb814-0243-11e6-90d2-536c58d1b1a7.png)
![screen shot 2016-04-14 at 1 15 48 pm](https://cloud.githubusercontent.com/assets/776987/14538787/0a14f938-0243-11e6-86c7-13c7af166b5e.png)
