### PR TITLE
Functional CFR ToC tab

### DIFF
--- a/regulations/static/regulations/js/source/helpers.js
+++ b/regulations/static/regulations/js/source/helpers.js
@@ -323,7 +323,8 @@ module.exports = {
       return {
         path: path,
         hash: parts.join('-'),
-        docId: docId
+        docId: docId,
+        type: type
       };
     }
 };

--- a/regulations/static/regulations/js/source/views/main/preamble-view.js
+++ b/regulations/static/regulations/js/source/views/main/preamble-view.js
@@ -25,7 +25,7 @@ var PreambleView = ChildView.extend({
     this.options = options;
 
     var parsed = helpers.parsePreambleId(this.options.id);
-    var type = parsed.path[0];
+    var type = parsed.type;
 
     this.id = [parsed.docId].concat(parsed.path).join('-');
     this.options.scrollToId = parsed.hash;
@@ -42,7 +42,14 @@ var PreambleView = ChildView.extend({
     this.listenTo(MainEvents, 'paragraph:active', this.handleParagraphActive);
 
     CommentEvents.trigger('comment:readTabOpen');
-    DrawerEvents.trigger('pane:init', type === 'preamble' ? 'table-of-contents' : 'table-of-contents-secondary');
+
+    if (type === 'preamble') {
+      DrawerEvents.trigger('pane:init', 'table-of-contents');
+    }
+    else if (type === 'cfr') {
+      DrawerEvents.trigger('pane:init', 'table-of-contents-secondary');
+      DrawerEvents.trigger('pane:change', 'table-of-contents-secondary');
+    }
   },
 
   handleRead: function() {

--- a/regulations/templates/regulations/comment-review-chrome.html
+++ b/regulations/templates/regulations/comment-review-chrome.html
@@ -5,8 +5,12 @@
 {% block title %}Preamble {{doc_number}}{% endblock %}
 
 {% block sidebar-icons %}
-<li><a href="#table-of-contents" id="menu-link" class="toc-nav-link current" title="Table of Contents"><span class="icon-text">Table of Contents</span><img src="{%static "regulations/img/table-of-contents.svg" %}"
-       class="drawer-toggle-icon" alt="Table of Contents toggle" /></a></li>
+<li>
+  <a href="#table-of-contents" id="menu-link" class="toc-nav-link current" title="Preamble Table of Contents">Pre</a>
+</li>
+<li>
+  <a href="#table-of-contents-secondary" id="table-of-contents-secondary-link" class="toc-nav-link" title="CFR Changes">CFR</a>
+</li>
 {% endblock %}
 
 {% block wayfinding %}{% endblock %}
@@ -20,6 +24,7 @@
   <div class="toc-drawer toc-container current hidden diff-toc" id="table-of-contents">
     <div class="drawer-header">
       <h3 class="toc-type">Table of Contents</h3>
+      <h5 class="toc-subheader">Preamble</h5>
     </div><!-- /.drawer-header -->
     <nav id="toc" class="regulation-nav drawer-content" role="navigation">
       <ol>
@@ -39,6 +44,27 @@
       </ol>
     </nav>
   </div>
+
+  <div id="table-of-contents-secondary" class="toc-container hidden">
+    <div class="drawer-header">
+      <h3 class="toc-type">Table of Contents</h3>
+      <h5 class="toc-subheader">Amendments to the CFR</h5>
+    </div>
+    <nav id="cfr-toc" class="regulation-nav drawer-content" role="navigation">
+      <ol>
+        {% for cfr_part_toc in cfr_change_toc %}
+          <li>
+            <h3 class="subpart-heading">{{cfr_part_toc.title}} CFR {{cfr_part_toc.part}}</h3>
+          </li>
+          <li><a href="{{cfr_part_toc.authority_url}}">Authority</a></li>
+          {% for section_toc in cfr_part_toc.sections %}
+            <li><a href="{{section_toc.url}}" data-section-id="{{section_toc.full_id}}">{{section_toc.title}}</a></li>
+          {% endfor %}
+        {% endfor %}
+      </ol>
+    </nav>
+  </div>
+
 </div> <!-- /.panel -->
 {% endblock %}
 


### PR DESCRIPTION
Updated `DrawerEvents` so CFR ToC tab stays open while browsing CFR pages.
Related to eregs/notice-and-comment#117