### PR TITLE
Fix Sauce tests, effective date issue

### DIFF
--- a/regulations/uitests/definition_test.py
+++ b/regulations/uitests/definition_test.py
@@ -18,7 +18,7 @@ class DefinitionTest(BaseTest, unittest.TestCase):
         WebDriverWait(self.driver, 30).until(
             lambda driver: 'selenium-start' in html.get_attribute('class'))
         definition_link = self.driver.find_element_by_xpath(
-            '//*[@id="1005-1-a"]/p/a')
+            '//*[@id="1005-1-a"]//a')
         # term link should have correct data attr
         self.assertTrue(
             '1005-2-a-1' in definition_link.get_attribute('data-definition'))

--- a/regulations/uitests/definition_test.py
+++ b/regulations/uitests/definition_test.py
@@ -64,7 +64,7 @@ class DefinitionTest(BaseTest, unittest.TestCase):
 
         # load 1005.3, open definition
         new_definition_link = self.driver.find_element_by_xpath(
-            '//*[@id="1005-3-a"]/p/a[1]')
+            '//*[@id="1005-3-a"]//a[1]')
         new_definition_link.click()
         self.driver.find_element_by_xpath('//*[@id="1005-2-b-1"]')
 

--- a/regulations/uitests/subheader_test.py
+++ b/regulations/uitests/subheader_test.py
@@ -1,0 +1,13 @@
+import unittest
+
+from regulations.uitests.base_test import BaseTest
+
+
+class SubheaderTests(BaseTest, unittest.TestCase):
+    def job_name(self):
+        return 'Subheader tests'
+
+    def test_effective_date(self):
+        self.driver.get(self.test_url + '/1005-1/2012-12121')
+        effective = self.driver.find_element_by_class_name('effective-date')
+        self.assertIn('10/28/2012', effective.text)

--- a/regulations/views/utils.py
+++ b/regulations/views/utils.py
@@ -4,6 +4,7 @@ import logging
 
 from regulations.generator import api_reader, generator
 from regulations.generator.layers.tree_builder import roman_nums
+from regulations.generator.layers.utils import convert_to_python
 from regulations.generator.toc import fetch_toc
 
 
@@ -34,7 +35,7 @@ def regulation_meta(cfr_part, version):
     meta = {}
     for data in layer_data.get(cfr_part, []):
         meta.update(data)
-    return meta
+    return convert_to_python(meta)
 
 
 def layer_names(request):


### PR DESCRIPTION
Resolves eregs/notice-and-comment#148, which was introduced in the #189 refactor. Adds a sauce test as an integration validation.

Resolves #237 by using a more generic selector.

Sorry for breaking convention re forks vs branches. I wanted a quick way to test Sauce without needing to set it up locally.