### PR TITLE
Add option to run selenium tests locally.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -136,7 +136,7 @@ module.exports = function(grunt) {
 
     shell: {
       'nose-chrome': {
-        command: 'nosetests -s <%= env.testPath %> --tc=webdriver.browser:chrome --tc=testUrl:<%= env.testUrl %>',
+        command: 'nosetests -s <%= env.testPath %> --tc=remote:chrome --tc=testUrl:<%= env.testUrl %>',
         options: {
             stdout: true,
             stderr: true
@@ -144,7 +144,7 @@ module.exports = function(grunt) {
       },
 
       'nose-ie11': {
-        command: 'nosetests -s <%= env.testPath %> --tc=webdriver.browser:ie11 --tc=testUrl:<%= env.testUrl %>',
+        command: 'nosetests -s <%= env.testPath %> --tc=remote:ie11 --tc=testUrl:<%= env.testUrl %>',
         options: {
             stdout: true,
             stderr: true

--- a/README.md
+++ b/README.md
@@ -144,10 +144,10 @@ $ ./bin/django runserver
 ## Additional front end information
 
 ### Running Grunt tasks
-There are a number of tasks configured in [Gruntfile.js](https://github.com/eregs/regulations-site/blob/master/Gruntfile.js). On the last lines, you will find tasks that group subtasks into common goals. Running ```grunt build``` will run unit, functional and lint tests, and compress static assets. Its recommended that you run this task before deploying changes.
+There are a number of tasks configured in [Gruntfile.js](https://github.com/eregs/regulations-site/blob/master/Gruntfile.js). On the last lines, you will find tasks that group subtasks into common goals. Running `grunt test` will run unit, functional and lint tests.
 
 ### Unit and Functional Tests
-The Grunt build will run a suite of Selenium tests written in Python and a small suite of [Mocha.js](http://visionmedia.github.io/mocha/) unit tests. All tests run in [Sauce Labs](https://saucelabs.com). These tests run as part of the ```grunt build``` tasks. To use these, a little extra environment setup is required.
+The Grunt build will run a suite of Selenium tests written in Python and a small suite of [Mocha.js](http://visionmedia.github.io/mocha/) unit tests. All tests run in [Sauce Labs](https://saucelabs.com). These tests run as part of the `grunt test` task. To use these, a little extra environment setup is required.
 
 #### Sauce Labs Configuration
 After you create a [Sauce Labs](https://saucelabs.com) account:
@@ -158,6 +158,8 @@ After you create a [Sauce Labs](https://saucelabs.com) account:
 ##### For functional tests
 - They also require having the environment serving data from ```dummy_api/```. To start the dummy API, from the root of your repo, run ```./dummy_api/start.sh 0.0.0.0:8282```.
 - The tests run using [nose](http://nose.readthedocs.org/en/latest/). If you wish to run the tests outside of the Grunt environment, you may by running ```nosetests regulations/uitests/*.py``` from the root of the repo.
+- By default, functional tests run using a local PhantomJS driver. To run using a different local browser, pass the `local` option, e.g. `tc=local:Chrome`; the option should be a webdriver class within the `selenium.webdriver` module.
+- To run tests using Sauce Labs, set the `remote` option to a key in `regulations.uitests.base_test:remote_configs`, e.g. `--tc=remote:ie11`. Alternatively, run `grunt nose` to run against all configured browsers on Sauce Labs, or `grunt shell:nose-chrome` to run against a single remote browser.
 
 ##### For unit tests
 - Unit tests do not require running the dummy API.

--- a/regulations/uitests/base_test.py
+++ b/regulations/uitests/base_test.py
@@ -3,45 +3,61 @@ from selenium import webdriver
 from testconfig import config
 
 
+remote_configs = {
+    'chrome': {
+        'driver': webdriver.DesiredCapabilities.CHROME,
+        'platform': 'LINUX',
+        'version': '',
+    },
+    'ie11': {
+        'driver': webdriver.DesiredCapabilities.INTERNETEXPLORER,
+        'platform': 'Windows 10',
+        'version': '11',
+    }
+}
+
+
 class BaseTest():
 
-    def config_map(self, browser):
-        browser_configs = {
-            'chrome': {
-                'driver': webdriver.DesiredCapabilities.CHROME,
-                'platform': 'LINUX',
-                'version': '',
-            },
-            'ie11': {
-                'driver': webdriver.DesiredCapabilities.INTERNETEXPLORER,
-                'platform': 'Windows 10',
-                'version': '11',
-            }
-        }
-        return browser_configs[browser]
-
     def setUp(self):
-        selenium_config = self.config_map(config['webdriver']['browser'])
         self.test_url = config['testUrl']
-        self.capabilities = selenium_config['driver']
+        self.driver = (
+            self.make_remote()
+            if 'remote' in config
+            else self.make_local()
+        )
+        self.driver.implicitly_wait(30)
+
+    def make_local(self):
+        attr = config.get('local', 'PhantomJS')
+        klass = getattr(webdriver, attr)
+        if not isinstance(klass, type):
+            raise TypeError(
+                'Option {} did not resolve to a class'.format(attr))
+        return klass()
+
+    def make_remote(self):
+        selenium_config = remote_configs[config['remote']]
+        capabilities = selenium_config['driver']
         if (os.environ.get('TRAVIS')
                 and os.environ.get('TRAVIS_SECURE_ENV_VARS')):
-            self.capabilities['tunnel-identifier'] = \
-                os.environ['TRAVIS_JOB_NUMBER']
-            self.capabilities['build'] = os.environ['TRAVIS_BUILD_NUMBER']
+            capabilities.update({
+                'tunnel-identifier': os.environ['TRAVIS_JOB_NUMBER'],
+                'build': os.environ['TRAVIS_BUILD_NUMBER'],
+            })
 
-        self.username = os.environ['SAUCE_USERNAME']
-        self.key = os.environ['SAUCE_ACCESS_KEY']
-        self.capabilities['name'] = self.job_name()
-        self.capabilities['platform'] = selenium_config['platform']
-        self.capabilities['version'] = selenium_config['version']
-        hub_url = "%s:%s" % (self.username, self.key)
+        username = os.environ['SAUCE_USERNAME']
+        key = os.environ['SAUCE_ACCESS_KEY']
+        capabilities['name'] = self.job_name()
+        capabilities['platform'] = selenium_config['platform']
+        capabilities['version'] = selenium_config['version']
+        hub_url = "%s:%s" % (username, key)
         executor = "http://%s@ondemand.saucelabs.com:80/wd/hub" % hub_url
-        self.driver = webdriver.Remote(desired_capabilities=self.capabilities,
-                                       command_executor=executor)
-        self.jobid = self.driver.session_id
-        print("Sauce Labs job: https://saucelabs.com/jobs/%s" % self.jobid)
-        self.driver.implicitly_wait(30)
+        driver = webdriver.Remote(desired_capabilities=capabilities,
+                                  command_executor=executor)
+        jobid = driver.session_id
+        print("Sauce Labs job: https://saucelabs.com/jobs/%s" % jobid)
+        return driver
 
     def job_name(self):
         return 'eRegs UI Test'


### PR DESCRIPTION
If no `remote` option is passed to `nose`, run tests with a local
selenium webdriver, defaulting to phantomjs. To switch local drivers,
pass the `local` option, e.g. `--tc=local:Firefox`; the value should
corresponding to the class name of the desired driver in the
`selenium.webdriver` module.

Note--not all tests pass locally. I'm guessing that this is related to timing issues (tests tend to run faster locally than on a remote vm, and we may be implicitly depending on that latency). Or I got the local configuration wrong, but there's very little going on there. I would suggest fixing the local tests in a separate issue, although it would be fine to address that here instead.