### PR TITLE
Fix broken write comment link

### DIFF
--- a/regulations/static/regulations/js/source/views/main/preamble-view.js
+++ b/regulations/static/regulations/js/source/views/main/preamble-view.js
@@ -57,9 +57,11 @@ var PreambleView = ChildView.extend({
 
   handleWriteLink: function(e) {
     var $target = $(e.target);
+    var $dataTarget = $target.closest('.activate-write');
+
     this.write(
-      $target.data('section'),
-      $target.data('label'),
+      $dataTarget.data('section'),
+      $dataTarget.data('label'),
       $target.closest('[data-permalink-section]')
     );
 


### PR DESCRIPTION
We moved the link to add a comment into a new div, which didn't have the same
attributes. This uses `closest` to be a little more resilient.

Resolves eregs/notice-and-comment#153