### PR TITLE
First pass at rule intro

### DIFF
--- a/regulations/generator/html_builder.py
+++ b/regulations/generator/html_builder.py
@@ -200,7 +200,10 @@ class PreambleHTMLBuilder(HTMLBuilder):
         is_markerless = node_types.MARKERLESS_REGEX.match
         prefix = list(takewhile(lambda l: not is_markerless(l),
                                 node['label']))
-        if len(prefix) > 1:
+        if 'intro' in prefix:
+            title = node.get('title', '').rstrip(':')
+            return 'Intro: ' + title
+        elif len(prefix) > 1:
             label = 'Section ' + '.'.join(prefix[1:])
             count = len(node['label']) - len(prefix)
             if count:

--- a/regulations/static/regulations/js/source/views/main/child-view.js
+++ b/regulations/static/regulations/js/source/views/main/child-view.js
@@ -134,7 +134,7 @@ var ChildView = Backbone.View.extend({
         this.$contentHeader = this.$contentHeader || $('header.reg-header');
 
         // sections that are eligible for being the active section
-        this.$contentContainer = $('#' + this.id).find('.level-1 li[id], .reg-section, .appendix-section, .supplement-section');
+        this.$contentContainer = $('#' + this.id).find('li[id], .reg-section, .appendix-section, .supplement-section');
 
         // cache jQobjs of each reg section
         len = this.$contentContainer.length;

--- a/regulations/static/regulations/js/source/views/main/preamble-view.js
+++ b/regulations/static/regulations/js/source/views/main/preamble-view.js
@@ -57,9 +57,11 @@ var PreambleView = ChildView.extend({
 
   handleWriteLink: function(e) {
     var $target = $(e.target);
+    var $dataTarget = $target.closest('.activate-write');
+
     this.write(
-      $target.data('section'),
-      $target.data('label'),
+      $dataTarget.data('section'),
+      $dataTarget.data('label'),
       $target.closest('[data-permalink-section]')
     );
 

--- a/regulations/templates/regulations/tree/preamble_intro.html
+++ b/regulations/templates/regulations/tree/preamble_intro.html
@@ -1,0 +1,34 @@
+{% comment %}
+    Preamble intro has lots of extra fields
+{% endcomment %}
+
+<li
+    {% if node.marker %}marker-type="{{node.marker}}"{% endif %}
+    id="{{node.markup_id}}" data-permalink-section
+>
+    <h4>{{ meta.primary_agency }}</h4>
+    <h3>{{ meta.title }}</h3>
+    <div>
+      <div>{{ meta.days_remaining }} Days</div>
+      <h5>Comment period closes on {{ meta.comments_close|date:"F j, Y" }} at 11:59pm
+        EST.</h5>
+      Rule published {{ meta.publication|date:"F j, Y"}} 
+    </div>
+    {% comment %}Jump links will go here{% endcomment %}
+    <hr />
+    <p>
+      {% for title_info in meta.cfr_parts %}
+        {{title_info.title}} CFR Parts {{ title_info.parts|join:", " }}<br />
+      {% endfor %}
+      {{meta.dockets|join:"; "}}<br />
+      {{meta.rins|join:"; "}}
+    </p>
+</li>
+<li><h4>Agency:</h4><p>{{ meta.agencies|join:", " }}.</p></li>
+<li><h4>Action:</h4><p>{{ meta.action}}.</p></li>
+{% for c in node.children %}
+  {% with node=c %}
+    {% include node.template_name %}
+  {% endwith %}
+{% endfor %}
+

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from copy import deepcopy
 from datetime import date
 
 from django.conf import settings
@@ -170,6 +171,34 @@ def make_preamble_toc(nodes, depth=1, max_depth=3):
     ]
 
 
+def common_context(doc_number):
+    """All of the "preamble" views share common context, such as preamble
+    data, toc info, etc. This function retrieves that data and returns the
+    results as a dict. This may throw a 404"""
+    preamble = ApiReader().preamble(doc_number)
+    if preamble is None:
+        raise Http404
+
+    # @todo - right now we're shimming in fake data; eventually this data
+    # should come from the API
+    intro = getattr(settings, 'PREAMBLE_INTRO', {}).get(doc_number, {})
+    intro = deepcopy(intro)
+    if intro.get('tree'):
+        preamble['children'].insert(0, intro['tree'])
+    intro['meta'] = convert_to_python(intro.get('meta', {}))
+    if 'comments_close' in intro['meta']:
+        intro['meta']['days_remaining'] = 1 + (
+            intro['meta']['comments_close'].date() - date.today()).days
+
+    return {
+        'cfr_change_toc': CFRChangeToC.for_doc_number(doc_number),
+        "doc_number": doc_number,
+        "meta": intro['meta'],
+        "preamble": preamble,
+        'preamble_toc': make_preamble_toc(preamble['children']),
+    }
+
+
 class PreambleView(View):
     """Displays either a notice preamble (or a subtree of that preamble). If
     using AJAX or specifically requesting, generate only the preamble markup;
@@ -177,38 +206,21 @@ class PreambleView(View):
     def get(self, request, *args, **kwargs):
         label_parts = kwargs.get('paragraphs', '').split('/')
         doc_number = label_parts[0]
-        preamble = ApiReader().preamble(doc_number)
-        if preamble is None:
-            raise Http404
+        context = common_context(doc_number)
 
-        # @todo - right now we're shimming in fake data; eventually this data
-        # should come from the API
-        intro = getattr(settings, 'PREAMBLE_INTRO', {}).get(doc_number, {})
-        if intro.get('tree'):
-            preamble['children'].insert(0, intro['tree'])
-        intro['meta'] = convert_to_python(intro.get('meta', {}))
-        if 'comments_close' in intro['meta']:
-            intro['meta']['days_remaining'] = 1 + (
-                intro['meta']['comments_close'].date() - date.today()).days
-
-        subtree = find_subtree(preamble, label_parts)
+        subtree = find_subtree(context['preamble'], label_parts)
         if subtree is None:
             raise Http404
 
-        id_prefix = [doc_number, 'preamble']
-        context = generate_html_tree(subtree, request, id_prefix=id_prefix)
-        context['meta'] = intro['meta']
+        sub_context = generate_html_tree(subtree, request,
+                                         id_prefix=[doc_number, 'preamble'])
+        template = sub_context['node']['template_name']
 
-        template = context['node']['template_name']
-
-        context = {
-            'sub_context': context,
+        context.update({
+            'sub_context': sub_context,
             'sub_template': template,
-            'doc_number': doc_number,
-            'full_id': context['node']['full_id'],
-            'preamble_toc': make_preamble_toc(preamble['children']),
-            'cfr_change_toc': CFRChangeToC.for_doc_number(doc_number)
-        }
+            'full_id': sub_context['node']['full_id']})
+
         if not request.is_ajax() and request.GET.get('partial') != 'true':
             template = 'regulations/preamble-chrome.html'
         else:
@@ -218,21 +230,11 @@ class PreambleView(View):
 
 
 class PrepareCommentView(View):
-    def get(self, request, *args, **kwargs):
-        preamble = ApiReader().preamble(kwargs['doc_number'])
-        if preamble is None:
-            raise Http404
+    def get(self, request, doc_number):
+        context = common_context(doc_number)
 
-        subtree = find_subtree(preamble, [kwargs['doc_number']])
-        if subtree is None:
-            raise Http404
-
-        id_prefix = [kwargs['doc_number'], 'preamble']
-        context = generate_html_tree(subtree, request, id_prefix=id_prefix)
-        context.update({
-            'preamble': preamble,
-            'doc_number': kwargs['doc_number'],
-        })
+        context.update(generate_html_tree(context['preamble'], request,
+                                          id_prefix=[doc_number, 'preamble']))
         template = 'regulations/comment-review-chrome.html'
 
         return TemplateResponse(request=request, template=template,
@@ -242,35 +244,31 @@ class PrepareCommentView(View):
 # @todo - this shares a lot of code w/ PreambleView. Can we merge them?
 class CFRChangesView(View):
     def get(self, request, doc_number, section):
+        context = common_context(doc_number)
+
         cfr_changes = getattr(settings, 'CFR_CHANGES', {})  # mock
         if doc_number not in cfr_changes:
             raise Http404("Doc # {} not found".format(doc_number))
-        preamble = ApiReader().preamble(doc_number)
-        if preamble is None:
-            raise Http404
         versions = cfr_changes[doc_number]["versions"]
         amendments = cfr_changes[doc_number]["amendments"]
         label_parts = section.split('-')
 
         if len(label_parts) == 1:
-            context = self.authorities_context(amendments, cfr_part=section)
+            sub_context = self.authorities_context(
+                amendments, cfr_part=section)
         else:
-            context = self.regtext_changes_context(
+            sub_context = self.regtext_changes_context(
                 amendments,
                 versions,
                 doc_number=doc_number,
                 label_id=section,
             )
 
-        context = {
-            'sub_context': context,
+        context.update({
+            'sub_context': sub_context,
             'sub_template': 'regulations/cfr_changes.html',
-            'preamble': preamble,
-            'doc_number': doc_number,
-            'full_id': '{}-cfr-{}'.format(doc_number, section),
-            'preamble_toc': make_preamble_toc(preamble['children']),
-            'cfr_change_toc': CFRChangeToC.for_doc_number(doc_number)
-        }
+            'full_id': '{}-cfr-{}'.format(doc_number, section)
+        })
 
         if not request.is_ajax() and request.GET.get('partial') != 'true':
             template = 'regulations/preamble-chrome.html'


### PR DESCRIPTION
As the data isn't actually available yet, this pulls the rule intro sections from a configuration. This doesn't include any new styles, so it looks pretty minimal.

Builds on #243 and resolves eregs/notice-and-comment#151

Looks like
<img width="1214" alt="screen shot 2016-04-15 at 3 56 45 pm" src="https://cloud.githubusercontent.com/assets/326918/14573442/127e52aa-0323-11e6-975f-8c7eacd20e08.png">
<img width="1139" alt="screen shot 2016-04-15 at 3 57 35 pm" src="https://cloud.githubusercontent.com/assets/326918/14573443/15a36aa6-0323-11e6-8c8a-f0e377485c43.png">

