### PR TITLE
Old eRegs ToC cleanup

### DIFF
--- a/regulations/static/regulations/css/less/module/drawer-content.less
+++ b/regulations/static/regulations/css/less/module/drawer-content.less
@@ -5,7 +5,7 @@ This contains all of the styles specific to the TOC
 */
 .regulation-nav {
 
-    padding-top: 32px;
+    padding-top: 40px;
 
     &.preamble-nav {
       padding-top: 72px;
@@ -89,15 +89,17 @@ This contains all of the styles specific to the TOC
     color: #d14124;
 }
 
+
+/* Negative margin, positive padding to extend borders full width */
 .subpart-heading {
-    margin: 0;
+    margin: 0 0 0 -10px;
     padding: 10px 15px;
     display: block;
+    line-height: 1.4;
     background-color: #F8F8F8;
     .border-bottom-light (@width: 1px);
     .border-top-light (@width: 1px);
     .regulation-nav-subpart-heading-font;
-
 }
 
 .subpart-subhead {


### PR DESCRIPTION
Some small changes to fix the 5px gutter left in old eregs by recent table of contents changes

![screen shot 2016-04-15 at 4 21 21 pm](https://cloud.githubusercontent.com/assets/776987/14575232/205b3fca-0326-11e6-97a5-08508be5c179.png)
