### PR TITLE
Fix ajax navigation to cfr changes from index view.

### DIFF
--- a/regulations/static/regulations/js/source/helpers.js
+++ b/regulations/static/regulations/js/source/helpers.js
@@ -318,7 +318,9 @@ module.exports = {
         path = path.concat(parts.slice(1, 2));
         section = [docId].concat(parts.slice(1, 2));
       } else if (type === 'cfr') {
-        path = path.concat(['cfr_changes', parts.join('-')]);
+        // Sections for CFR changes include the two first parts; the ID
+        // 478-32-p243 maps to the section 478-32
+        path = path.concat(['cfr_changes', parts.slice(0, 2).join('-')]);
         section = parts.slice(0, 2);
       }
       return {


### PR DESCRIPTION
Ajax navigation from the cfr changes toc currently works as expected,
but navigation to cfr changes from the comment index can request pages
that are too deep, e.g. 478-11-p2. This patch limits the `section` key
of the cfr change url to two path elements.