### PR TITLE
Comment index icons

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -208,6 +208,7 @@ a.comment-index-review {
     cursor: default;
     font-weight: 500;
     padding: 15px;
+    margin-top: 10px;
 
     .comment-index-section {
       float: left;
@@ -221,7 +222,9 @@ a.comment-index-review {
 
       .fa {
         vertical-align: middle;
+        visibility: hidden;
         margin-left: 5px;
+        color: @dark_field;
 
         &:hover {
           color: darken(@black, 10%);
@@ -239,7 +242,11 @@ a.comment-index-review {
     }
 
     &:hover {
-      background: darken(@80_gray, 10%);;
+      background: darken(@80_gray, 10%);
+
+      .fa {
+        visibility: visible;
+      }
     }
   }
 }

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -215,10 +215,18 @@ a.comment-index-review {
     }
 
     .comment-index-modify {
-      font-size: 13px;
+      font-size: 15px;
       float: right;
-      line-height: 20px;
       width: 40px;
+
+      .fa {
+        vertical-align: middle;
+        margin-left: 5px;
+
+        &:hover {
+          color: darken(@black, 10%);
+        }
+      }
     }
 
     .comment-index-edit,

--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -11,7 +11,7 @@
         data-label="{{ node.human_label }}">
 
         <div class="paragraph-comment-icon">
-          <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
+          <span class="fa fa-pencil-square-o" aria-hidden="true"></span>
         </div>
        <div class="paragraph-comment">Write a comment about {{ node.human_label }}</div>
     </div>

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -46,8 +46,8 @@
         data-comment-label="<%= comment.label %>">
       <div class="comment-index-section"><%= comment.label %></div>
       <div class="comment-index-modify">
-        <span class="comment-index-edit">edit</span>
-        <span class="comment-index-clear">remove</span>
+        <a class="comment-index-edit" title="Edit Comment"><i class="fa fa-pencil-square-o"></i></a>
+        <a class="comment-index-clear" title="Remove Comment"><i class="fa fa-times"></i></a>
       </div>
     </li>
   <% }); %>

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -46,8 +46,8 @@
         data-comment-label="<%= comment.label %>">
       <div class="comment-index-section"><%= comment.label %></div>
       <div class="comment-index-modify">
-        <a class="comment-index-edit" title="Edit Comment"><i class="fa fa-pencil-square-o"></i></a>
-        <a class="comment-index-clear" title="Remove Comment"><i class="fa fa-times"></i></a>
+        <a class="comment-index-edit" title="Edit Comment"><span class="fa fa-pencil-square-o"></span></a>
+        <a class="comment-index-clear" title="Remove Comment"><span class="fa fa-times"></span></a>
       </div>
     </li>
   <% }); %>


### PR DESCRIPTION
Adding icons to the comment index

Fixes eregs/notice-and-comments#137

<img width="243" alt="screen shot 2016-04-18 at 12 23 30 pm" src="https://cloud.githubusercontent.com/assets/776987/14613148/a6ba34a4-0560-11e6-94d1-cff8deab3772.png">

<img width="299" alt="screen shot 2016-04-18 at 12 25 41 pm" src="https://cloud.githubusercontent.com/assets/776987/14613158/b4a1926a-0560-11e6-859c-8705572ccb9c.png">
