### PR TITLE
fix width on preamble

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -8,10 +8,8 @@ comment.less contains styles related to commenting on sections
   margin: 0;
   padding: 0 0 0 15px;
 
-  section {
-    h2, h3, h4, h5, h6, p, .extract {
-      width: 70%;
-    }
+  h2, h3, h4, h5, h6, p, .extract {
+    width: 70%;
   }
 
   // for paragraphs, only show write comment link when hovered


### PR DESCRIPTION
Update CSS so preamble doesn't extend into "write a comment" links.