### PR TITLE
Remove setting deprecated since Django 1.8

### DIFF
--- a/regulations/settings/dev.py
+++ b/regulations/settings/dev.py
@@ -1,7 +1,6 @@
 from .base import *
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 CACHES['default']['BACKEND'] = 'django.core.cache.backends.dummy.DummyCache'
 CACHES['eregs_longterm_cache']['BACKEND'] = 'django.core.cache.backends.dummy.DummyCache'

--- a/regulations/tests/layers_interpretations_tests.py
+++ b/regulations/tests/layers_interpretations_tests.py
@@ -8,7 +8,7 @@ from regulations.generator.layers.interpretations import InterpretationsLayer
 class InterpretationsLayerTest(TestCase):
     def setUp(self):
         if not settings.configured:
-            settings.configure(TEMPLATE_DEBUG=False, API_BASE='')
+            settings.configure(API_BASE='')
 
     @patch('regulations.generator.layers.interpretations.generator')
     @patch('regulations.generator.layers.interpretations.SectionUrl')


### PR DESCRIPTION
The recommendation from the manual is:
Set the 'debug' option in the OPTIONS of a DjangoTemplates backend
instead.

As this 'debug' option tracks the DEBUG setting by default, we don't
need to set anything explicitly.