### PR TITLE
Preamble text flow updates

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -7,6 +7,7 @@ comment.less contains styles related to commenting on sections
 #preamble-read {
   margin: 0;
   padding: 0 0 0 15px;
+  word-wrap: break-word;
 
   // for paragraphs, only show write comment link when hovered
   .node:hover {
@@ -444,12 +445,6 @@ a.comment-index-review {
   }
 }
 
-.preamble-wrapper {
-  .footnote-box {
-    width: 70%;
-  }
-}
-
 // CFR
 .cfr-instructions {
   .font-regular;
@@ -487,6 +482,12 @@ a.comment-index-review {
   }
 
   #preamble-read {
+    padding-left: 0;
+
+    ol, ul {
+      padding-left: 0;
+    }
+
     li {
       h2, h3, h4, h5, h6, p {
         width: 100%;
@@ -533,5 +534,11 @@ a.comment-index-review {
   .preamble-wrapper {
     margin-right: 5%;
     padding-left: 35px;
+
+    // don't need max-width to account for a right sidebar
+    // so preamble text will fill the space when nav is minimized
+    &.close {
+      max-width: 100%;
+    }
   }
 }


### PR DESCRIPTION
* Preamble text now fills the space left when the ToC is minimized to the left. (As mentioned in #253)
* Set word wrap to break very long strings in the text, most noticeable when URLs widened the layout mobile view.
* Mobile view: flatten list indents to better utilize space for now.

<img width="1132" alt="screen shot 2016-04-18 at 11 35 45 pm" src="https://cloud.githubusercontent.com/assets/24054/14629875/8a98fee6-05be-11e6-971b-7e6af934db07.png">
<img width="297" alt="screen shot 2016-04-18 at 11 38 48 pm" src="https://cloud.githubusercontent.com/assets/24054/14629907/b9c76b94-05be-11e6-8823-b376c4b1c09c.png">
