### PR TITLE
check preamble type in template

### DIFF
--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -2,9 +2,14 @@
 
 <section id="{{full_id}}" class="reg-section" data-page-type="preamble-section" data-doc-id="{{doc_number}}">
   <div id="preamble-read">
+    {% if type == "preamble" %}
     <ul>
       {% render_nested template=sub_template context=sub_context %}
     </ul>
+    {% else %}
+      {% render_nested template=sub_template context=sub_context %}
+    {% endif %}
+
     {% include "regulations/footnotes.html" %}
   </div>
 

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -219,7 +219,9 @@ class PreambleView(View):
         context.update({
             'sub_context': sub_context,
             'sub_template': template,
-            'full_id': sub_context['node']['full_id']})
+            'full_id': sub_context['node']['full_id'],
+            'type': "preamble"
+        })
 
         if not request.is_ajax() and request.GET.get('partial') != 'true':
             template = 'regulations/preamble-chrome.html'
@@ -267,7 +269,8 @@ class CFRChangesView(View):
         context.update({
             'sub_context': sub_context,
             'sub_template': 'regulations/cfr_changes.html',
-            'full_id': '{}-cfr-{}'.format(doc_number, section)
+            'full_id': '{}-cfr-{}'.format(doc_number, section),
+            'type': "cfr"
         })
 
         if not request.is_ajax() and request.GET.get('partial') != 'true':


### PR DESCRIPTION
Mainly to know whether to wrap the `{{ sub_context }}` output in a `<ul>` tag, since the preamble view returns list items but CFR returns an instructions div and section.

<img width="1131" alt="screen shot 2016-04-19 at 12 02 32 am" src="https://cloud.githubusercontent.com/assets/24054/14630570/4dca0096-05c3-11e6-89ca-5f168b038c37.png">

<img width="1139" alt="screen shot 2016-04-19 at 12 01 10 am" src="https://cloud.githubusercontent.com/assets/24054/14630573/50b1a89a-05c3-11e6-844d-3bcaf480cd4c.png">
