### PR TITLE
Call out CFR comments

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -9,11 +9,15 @@ comment.less contains styles related to commenting on sections
   padding: 0 0 0 15px;
   word-wrap: break-word;
 
+  // for hiding write comment links on paragraphs
+  // when section is not called out for comment
   .not-called-out {
     .activate-write {
       display: none;
     }
 
+    // then show write comment links when paragraph
+    // section is hovered
     &:hover {
       .activate-write {
         display: block;

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -11,13 +11,13 @@ comment.less contains styles related to commenting on sections
 
   // for paragraphs, only show write comment link when hovered
   .node:hover {
-    > p + .activate-write {
+    > p + .activate-write:not(.called-out) {
       top: 15px;
       display: block;
     }
   }
 
-  p + .activate-write {
+  p + .activate-write:not(.called-out) {
     display: none;
   }
 }

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -9,16 +9,16 @@ comment.less contains styles related to commenting on sections
   padding: 0 0 0 15px;
   word-wrap: break-word;
 
-  // for paragraphs, only show write comment link when hovered
-  .node:hover {
-    > p + .activate-write:not(.called-out) {
-      top: 15px;
-      display: block;
+  .not-called-out {
+    .activate-write {
+      display: none;
     }
-  }
 
-  p + .activate-write:not(.called-out) {
-    display: none;
+    &:hover {
+      .activate-write {
+        display: block;
+      }
+    }
   }
 }
 
@@ -78,6 +78,10 @@ comment.less contains styles related to commenting on sections
   &:hover {
     color: @pacific_hover;
   }
+}
+
+p + .activate-write {
+  top: 15px;
 }
 
 .paragraph-comment-icon {

--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -45,7 +45,7 @@
         data-label="{{ node.human_label }}">
 
         <div class="paragraph-comment-icon">
-          <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
+          <span class="fa fa-pencil-square-o" aria-hidden="true"></span>
         </div>
        <div class="paragraph-comment">Write a comment about {{ node.human_label }}</div>
     </div>

--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -19,34 +19,40 @@
 </div>
 {% endif %}
 
-<div class="node">
-{%if node.marked_up %}
-<p {% if node.is_collapsed %}class="collapsed"{% endif %}>
-{% if node.paragraph_marker %}
-  <span class="stripped-marker">{{node.paragraph_marker}}.</span>
-{% endif %}
-<span class="paragraph-text">
-{% if node.node_type == "appendix" %}
-    {{node.marked_up|safe|linebreaksbr}}
-{% else  %}
-    {{node.marked_up|safe}}
-{% endif %}
-</span>
-</p>
+<div class="node{% if not node.comments_calledout %} not-called-out{% endif %}">
 
-{% if node.accepts_comments and not node.title %}
-  <div
-      class="activate-write{% if node.comments_calledout %} called-out{% endif %}"
-      data-section="{{ node.full_id }}"
-      data-label="{{ node.human_label }}">
+  {%if node.marked_up %}
+    <p {% if node.is_collapsed %}class="collapsed"{% endif %}>
 
-      <div class="paragraph-comment-icon">
-        <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
-      </div>
-     <div class="paragraph-comment">Write a comment about {{ node.human_label }}</div>
-  </div>
-{% endif %}
-{% endif %}
+      {% if node.paragraph_marker %}
+        <span class="stripped-marker">{{node.paragraph_marker}}.</span>
+      {% endif %}
+
+      <span class="paragraph-text">
+      {% if node.node_type == "appendix" %}
+          {{node.marked_up|safe|linebreaksbr}}
+      {% else  %}
+          {{node.marked_up|safe}}
+      {% endif %}
+      </span>
+
+    </p>
+
+    {% if node.accepts_comments and not node.title %}
+    <div
+        class="activate-write"
+        data-section="{{ node.full_id }}"
+        data-label="{{ node.human_label }}">
+
+        <div class="paragraph-comment-icon">
+          <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
+        </div>
+       <div class="paragraph-comment">Write a comment about {{ node.human_label }}</div>
+    </div>
+    {% endif %}
+
+  {% endif %}
+
 </div>
 
 {% if node.children %}

--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -33,10 +33,10 @@
 {% endif %}
 </span>
 </p>
-{% comment %}@TODO use node.comments_calledout{% endcomment %}
+
 {% if node.accepts_comments and not node.title %}
   <div
-      class="activate-write"
+      class="activate-write{% if node.comments_calledout %} called-out{% endif %}"
       data-section="{{ node.full_id }}"
       data-label="{{ node.human_label }}">
 


### PR DESCRIPTION
Write a comment links are always displayed on CFR, or specifically any comment that is "called out" in `node.html`.

Fixes eregs/notice-and-comment#134