### PR TITLE
Accessible links for adding comments

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -69,8 +69,6 @@ comment.less contains styles related to commenting on sections
 }
 
 .activate-write {
-  color: @pacific_light;
-  cursor: pointer;
   font-family: Arial, sans-serif;
   font-size: 15px;
   font-weight: bold;
@@ -79,7 +77,12 @@ comment.less contains styles related to commenting on sections
   top: -5px;
   width: 230px;
 
-  &:hover {
+  a {
+    color: @pacific_light;
+    display: block;
+  }
+
+  &:hover a, a:focus {
     color: @pacific_hover;
   }
 }

--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -9,11 +9,12 @@
         class="activate-write"
         data-section="{{ node.full_id }}"
         data-label="{{ node.human_label }}">
-
+      <a href="#">
         <div class="paragraph-comment-icon">
           <span class="fa fa-pencil-square-o" aria-hidden="true"></span>
         </div>
-       <div class="paragraph-comment">Write a comment about {{ node.human_label }}</div>
+        <div class="paragraph-comment">Write a comment about {{ node.human_label }}</div>
+      </a>
     </div>
   {% endif %}
 </div>
@@ -44,10 +45,12 @@
         data-section="{{ node.full_id }}"
         data-label="{{ node.human_label }}">
 
+      <a href="#">
         <div class="paragraph-comment-icon">
           <span class="fa fa-pencil-square-o" aria-hidden="true"></span>
         </div>
-       <div class="paragraph-comment">Write a comment about {{ node.human_label }}</div>
+        <div class="paragraph-comment">Write a comment about {{ node.human_label }}</div>
+      </a>
     </div>
     {% endif %}
 


### PR DESCRIPTION
Allow the user to tab through the "Write a comment about" links. This requires
a small tweak to the n&c stylesheets. It does not allow a user to comment on a
specific paragraph, but we've agreed that's okay given that the user can
comment on the whole section.

Towards eregs/notice-and-comment#166

Looks like:
![tabs](https://cloud.githubusercontent.com/assets/326918/14692089/ec432756-0722-11e6-9f8f-f7628f2521c9.gif)
