### PR TITLE
Fix bug with preamble intro

### DIFF
--- a/regulations/templates/regulations/tree/preamble_intro.html
+++ b/regulations/templates/regulations/tree/preamble_intro.html
@@ -24,8 +24,6 @@
       {{meta.rins|join:"; "}}
     </p>
 </li>
-<li><h4>Agency:</h4><p>{{ meta.agencies|join:", " }}.</p></li>
-<li><h4>Action:</h4><p>{{ meta.action}}.</p></li>
 {% for c in node.children %}
   {% with node=c %}
     {% include node.template_name %}

--- a/regulations/uitests/comment_test.py
+++ b/regulations/uitests/comment_test.py
@@ -49,3 +49,9 @@ class CommentTest(BaseTest, unittest.TestCase):
             '.comments').get_attribute('innerHTML')
         assert_in(comment_label, html)
         assert_in('i prefer not to', html)
+
+    def test_intro(self):
+        """Verify that the intro meta data is visible"""
+        self.driver.get(self.test_url + '/preamble/2016_02749/intro')
+        html = self.driver.find_element_by_tag_name('html')
+        self.assertIn('Addition of a Subsurface Intrusion Component', html)

--- a/regulations/uitests/comment_test.py
+++ b/regulations/uitests/comment_test.py
@@ -54,4 +54,5 @@ class CommentTest(BaseTest, unittest.TestCase):
         """Verify that the intro meta data is visible"""
         self.driver.get(self.test_url + '/preamble/2016_02749/intro')
         html = self.driver.find_element_by_tag_name('html')
-        self.assertIn('Addition of a Subsurface Intrusion Component', html)
+        self.assertIn('Addition of a Subsurface Intrusion Component',
+                      html.text)

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -215,6 +215,7 @@ class PreambleView(View):
         sub_context = generate_html_tree(subtree, request,
                                          id_prefix=[doc_number, 'preamble'])
         template = sub_context['node']['template_name']
+        sub_context['meta'] = context['meta']
 
         context.update({
             'sub_context': sub_context,
@@ -265,6 +266,7 @@ class CFRChangesView(View):
                 doc_number=doc_number,
                 label_id=section,
             )
+        sub_context['meta'] = context['meta']
 
         context.update({
             'sub_context': sub_context,


### PR DESCRIPTION
As a final step to #244, a bunch of code was DRYed out. Unfortunately, this
process introduced a bug where the "meta" information wasn't available when it
needed to be. This patch also removes two fields from the preamble_intro
template

Breaking convention again to verify the new selenium test runs without needing to set it up :D