### PR TITLE
Export HTML from text editor as well as markdown

### DIFF
--- a/regulations/static/regulations/js/source/models/comment-model.js
+++ b/regulations/static/regulations/js/source/models/comment-model.js
@@ -7,6 +7,7 @@ module.exports = Backbone.Model.extend({
   defaults: {
     label: '',
     comment: '',
+    commentHtml: '',
     files: []
   }
 });

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -147,6 +147,7 @@ var CommentView = Backbone.View.extend({
     e.preventDefault();
     this.model.set({
       comment: this.editor.getContent('markdown'),
+      commentHtml: this.editor.getContent('html'),
       files: _.map(this.attachmentViews, function(view) {
         return {
           key: view.options.key,

--- a/regulations/templates/regulations/comment-review-chrome.html
+++ b/regulations/templates/regulations/comment-review-chrome.html
@@ -18,7 +18,7 @@
             <li data-section="<%= comment.id %>">
               <h4><%= comment.label %></h4>
               <div class="comment-content">
-                <%= comment.comment %>
+                <%= comment.commentHtml %>
               </div>
               <% if (comment.files.length) { %>
                 <div class="comment-attachments">


### PR DESCRIPTION
We want to display the markdown rendered as HTML in the review screen. To do
that, carry around this generated HTML string within the Comment model

Note that all existing comments will need to be resaved.

Looks like:
<img width="831" alt="screen shot 2016-04-20 at 7 11 14 pm" src="https://cloud.githubusercontent.com/assets/326918/14693321/bb9bb93e-072b-11e6-8603-4ca78d776770.png">


Should resolve eregs/notice-and-comment#169