### PR TITLE
[issue #18] adding an arabic option for the CFR title number.

### DIFF
--- a/regulations/views/universal_landing.py
+++ b/regulations/views/universal_landing.py
@@ -49,6 +49,7 @@ def universal(request):
     context['cfr_title_text'] = regs[0]['meta']['cfr_title_text']
     context['cfr_title_number'] = utils.to_roman(
         regs[0]['meta']['cfr_title_number'])
+    context['cfr_titleno_arabic'] = regs[0]['meta']['cfr_title_number'])
 
     c = RequestContext(request, context)
     t = select_template([

--- a/regulations/views/universal_landing.py
+++ b/regulations/views/universal_landing.py
@@ -49,7 +49,7 @@ def universal(request):
     context['cfr_title_text'] = regs[0]['meta']['cfr_title_text']
     context['cfr_title_number'] = utils.to_roman(
         regs[0]['meta']['cfr_title_number'])
-    context['cfr_titleno_arabic'] = regs[0]['meta']['cfr_title_number'])
+    context['cfr_titleno_arabic'] = regs[0]['meta']['cfr_title_number']
 
     c = RequestContext(request, context)
     t = select_template([


### PR DESCRIPTION
Per https://github.com/18F/fec-eregs/issues/18, FEC needs the CFR title number in arabic instead of roman numerals. Adding that as an option in the view makes it available to any other clients who'd prefer arabic numbers, and avoids a patchy custom template tag on the FEC side.

cc @cmc333333 