### PR TITLE
Styling for CFR stars context expansion

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -24,6 +24,29 @@ comment.less contains styles related to commenting on sections
       }
     }
   }
+
+  // hidden content (with stars) on CFR
+  .show-more-context {
+    background-color: @grey;
+    color: @pacific;
+    font-size: 10px;
+    margin: 5px 0;
+    text-align: center;
+    width: 100%;
+
+    span {
+      font-size: 13px;
+      padding: 0 30px;
+    }
+  }
+
+  li > .show-more-context {
+    width: 70%;
+  }
+
+  .section-title {
+    width: 75%;
+  }
 }
 
 .preamble-header {
@@ -56,7 +79,7 @@ comment.less contains styles related to commenting on sections
 
 #preamble-write {
   padding-left: 15px;
-  width: 70%;
+  width: 75%;
 }
 
 #preamble-write,
@@ -65,17 +88,17 @@ comment.less contains styles related to commenting on sections
 }
 
 #preamble-read .node {
-  padding-right: 250px;
+  padding-right: 200px;
 }
 
 .activate-write {
   font-family: Arial, sans-serif;
-  font-size: 15px;
+  font-size: 14px;
   font-weight: bold;
   position: absolute;
-  right: -40px;
+  right: -100px;
   top: -5px;
-  width: 230px;
+  width: 250px;
 
   a {
     color: @pacific_light;
@@ -203,7 +226,7 @@ a.comment-index-review {
 .comment-index {
   .font-regular;
   position: absolute;
-  right: -320px;
+  right: -290px;
   top: 15px;
   width: 250px;
 

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -41,7 +41,7 @@ comment.less contains styles related to commenting on sections
   }
 
   li > .show-more-context {
-    width: 70%;
+    width: 75%;
   }
 
   .section-title {

--- a/regulations/static/regulations/js/source/views/main/stars-helpers.js
+++ b/regulations/static/regulations/js/source/views/main/stars-helpers.js
@@ -8,11 +8,14 @@ var $ = require('jquery');
  * addition to an $expander to expand collapsed $li texts. Each method returns
  * an updated $expander.
  */
+
+var starContent = '<button class="show-more-context">&#9733; &nbsp;&nbsp; &#9733; &nbsp;&nbsp; &#9733; <span>Show more context</span> &#9733; &nbsp;&nbsp; &#9733; &nbsp;&nbsp; &#9733;</button>';
+
 module.exports = {
   none: function() { return null; },  /* No changes, no new expander */
   inline: function($li) {
     var $toShow = $li.find('.paragraph-text:first').hide();
-    var $expander = $('<button>* * *</button>').insertBefore($toShow);
+    var $expander = $(starContent).insertBefore($toShow);
     var $paragraph = $expander.parent();
 
     $expander.click(function() {
@@ -38,7 +41,7 @@ module.exports = {
       $toShow = $li.hide();
     } else {
       $toShow = $li.children().hide();
-      $expander = $('<button>STARS</button>').insertBefore($toShow);
+      $expander = $(starContent).insertBefore($toShow);
       $expander.click(function() { $expander.remove(); });
     }
 


### PR DESCRIPTION
* Style context expansion with stars
* Widen content area a bit and move write comment link to the right to fill white space

eregs/notice-and-comment#125

<img width="1195" alt="screen shot 2016-04-21 at 11 53 08 am" src="https://cloud.githubusercontent.com/assets/24054/14720702/a3a3a38c-07b7-11e6-8b5e-6739285505d9.png">
<img width="1197" alt="screen shot 2016-04-21 at 11 14 24 am" src="https://cloud.githubusercontent.com/assets/24054/14719675/72ff6f18-07b2-11e6-852b-69ee3a3e4503.png">
