### PR TITLE
Separate search functions; use preamble header

### DIFF
--- a/regulations/generator/html_builder.py
+++ b/regulations/generator/html_builder.py
@@ -211,7 +211,7 @@ class PreambleHTMLBuilder(HTMLBuilder):
         elif len(prefix) > 1:
             label = 'Section ' + '.'.join(prefix[1:])
             count = len(node['label']) - len(prefix)
-            if count:
+            if count and node.get('indexes'):
                 paragraphs = '.'.join(
                     str(idx + 1)
                     for idx in node['indexes'][-count:]

--- a/regulations/tests/views_partial_search_tests.py
+++ b/regulations/tests/views_partial_search_tests.py
@@ -130,6 +130,24 @@ class PartialSearchTest(TestCase):
         response = Client().get('/partial/search/111?q=vvv')
         self.assertIn(b'provide a version', response.content)
 
+    @patch('regulations.views.partial_search.api_reader')
+    def test_preamble_search(self, api_reader):
+        api_reader.ApiReader.return_value.search.return_value = {
+            'total_hits': 3333,
+            'results': [
+                {'label': ['111_22', 'I', 'A'], 'text': 'tttt',
+                 'title': 'A. Something'},
+                {'label': ['111_22', 'I', 'p1'], 'text': 'eee'}
+            ]
+        }
+        response = Client().get('/partial/search/preamble/111?q=none')
+        self.assertIn(b'111_22-I-A', response.content)
+        self.assertIn(b'111_22-I-p1', response.content)
+        self.assertIn(b'tttt', response.content)
+        self.assertIn(b'eee', response.content)
+        self.assertIn(b'A. Something', response.content)
+        self.assertIn(b'Section I.A', response.content)
+
     def test_add_prev_next(self):
         view = PartialSearch()
         context = {'results': {'total_hits': 77}}


### PR DESCRIPTION
The transforms of search results were a bit hairy with special case logic;
this makes a single decision and diverts to either the CFR form or the
preamble form. It also uses the existing preamble header logic and adds a test

Resolves eregs/notice-and-comment#175