### PR TITLE
Better attachments

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "backbone.localstorage": "1.1.16",
     "clipboard": "1.5.5",
     "datatables.net": "1.10.10",
+    "filesize": "3.2.1",
     "jquery": "1.12.2",
     "jquery-lazyload": "1.9.7",
     "jquery-scrollstop": "1.2.0",

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -440,6 +440,7 @@ a.comment-index-review {
   }
 
   .comment-attachments {
+    display: block;
     margin-top: 5px;
     max-width: 480px;
 

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -214,7 +214,7 @@ p + .activate-write {
 }
 
 .comment-controls {
-  width: 75%;
+  width: 70%;
   float: left;
 
   button {
@@ -223,7 +223,7 @@ p + .activate-write {
 }
 
 .comment-submission {
-  width: 25%;
+  width: 30%;
   float: right;
 }
 

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -214,22 +214,23 @@ p + .activate-write {
 }
 
 .comment-controls {
-  width: 80%;
+  width: 75%;
   float: left;
+
+  button {
+    float: left;
+  }
 }
 
 .comment-submission {
-  width: 20%;
+  width: 25%;
   float: right;
 }
 
-
-
-.comment-wrapper .comment button,
-#comment-confirm button,
+.comment-button,
 a.comment-index-review {
   background-color: @pacific;
-  border-radius: 4px;
+  border-radius: 2px;
   color: #FFFFFF;
   .font-regular;
   font-weight: 500;
@@ -244,6 +245,23 @@ a.comment-index-review {
 
   &:hover {
     background-color: @pacific_hover;
+  }
+
+}
+
+.comment-upload-button {
+  background-color: @grey;
+  color: @black;
+  border-radius: 2px;
+  .font-regular;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  height: auto;
+  float: left;
+  padding: 8px 20px;
+
+  &:hover {
+    background-color: darken(@grey, 10%);
   }
 }
 
@@ -330,10 +348,11 @@ a.comment-index-review {
 
 .comment-attachments {
   margin-bottom: 5px;
+  display: inline-block;
 }
 
 .comment-attachment {
-  display: inline;
+  display: inherit;
   min-width: 300px;
   background: @grey;
   padding: 3px 10px;
@@ -345,6 +364,16 @@ a.comment-index-review {
 
   .attachment-filename {
     .font-bold;
+  }
+
+  .attachment-remove {
+    padding-left: 9px;
+    color: @80_gray;
+
+    &:hover {
+      color: @black;
+      cursor: pointer;
+    }
   }
 }
 

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -328,6 +328,26 @@ a.comment-index-review {
   margin: 15px 0 25px 0;
 }
 
+.comment-attachments {
+  margin-bottom: 5px;
+}
+
+.comment-attachment {
+  display: inline;
+  min-width: 300px;
+  background: @grey;
+  padding: 3px 10px;
+  margin-bottom: 3px;
+
+  span {
+    padding: 0 1px;
+  }
+
+  .attachment-filename {
+    .font-bold;
+  }
+}
+
 #comment-review {
   .font-regular;
   margin-bottom: 50px;

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -132,7 +132,7 @@ comment.less contains styles related to commenting on sections
     }
 
     .ProseMirror-content {
-      height: 130px;
+      height: 200px;
       resize: vertical;
       overflow-y: auto;
       padding: 12px 15px;
@@ -155,11 +155,23 @@ comment.less contains styles related to commenting on sections
   .status {
     clear: both;
     font-weight: bold;
-    padding: 5px 8px 0 0;
+    padding: 5px 0 0 0;
     text-align: right;
     width: 100%;
   }
 }
+
+.comment-controls {
+  width: 80%;
+  float: left;
+}
+
+.comment-submission {
+  width: 20%;
+  float: right;
+}
+
+
 
 .comment-wrapper .comment button,
 #comment-confirm button,

--- a/regulations/static/regulations/css/less/module/forms.less
+++ b/regulations/static/regulations/css/less/module/forms.less
@@ -39,6 +39,26 @@ input:focus {
     border: 1px solid @pacific;
 }
 
+.file-upload {
+    position: relative;
+    overflow: hidden;
+}
+.file-upload input[type=file] {
+    position: absolute;
+    top: 0;
+    right: 0;
+    min-width: 100%;
+    min-height: 100%;
+    font-size: 100px;
+    text-align: right;
+    filter: alpha(opacity=0);
+    opacity: 0;
+    outline: none;
+    background: white;
+    cursor: inherit;
+    display: block;
+}
+
 /*
 Selects
 --------------------------------

--- a/regulations/static/regulations/css/less/module/forms.less
+++ b/regulations/static/regulations/css/less/module/forms.less
@@ -1,6 +1,6 @@
 /*
 Forms.less
-========================================================================== 
+==========================================================================
 formsless contains generic form styles
 */
 
@@ -34,7 +34,7 @@ button:active {
     background-color: @pacific_hover;
 }
 
-textarea:focus, 
+textarea:focus,
 input:focus {
     border: 1px solid @pacific;
 }
@@ -44,17 +44,17 @@ Selects
 --------------------------------
 */
 
-.select-content { 
+.select-content {
     overflow: hidden; /* this hides the select's drop button */
     position: relative;
-    background: white url('../img/select.png') no-repeat bottom right; 
+    background: white url('../img/select.png') no-repeat bottom right;
     //width: 100%;
     border: solid 1px @light_field;
     height: 32px;
 }
 
-@media 
-(-webkit-min-device-pixel-ratio: 2), 
+@media
+(-webkit-min-device-pixel-ratio: 2),
 (min-resolution: 192dpi) {
     .select-content {
         background: white url('../img/select@2x.png') no-repeat bottom right;
@@ -62,12 +62,12 @@ Selects
     }
 }
 
-select { 
+select {
     width: 115%;
-    background-color: transparent; 
-    background-image: none; 
+    background-color: transparent;
+    background-image: none;
     -webkit-appearance: none;
-    border: none; 
+    border: none;
     box-shadow: none;
     padding: 0 10px; /* add padding to the select, not the div */
     color: @dark_text;

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -3,6 +3,7 @@
 var $ = require('jquery');
 var _ = require('underscore');
 var Backbone = require('backbone');
+var filesize = require('filesize');
 Backbone.$ = $;
 
 var edit = require('prosemirror/dist/edit');
@@ -121,7 +122,7 @@ var CommentView = Backbone.View.extend({
           $parent: this.$attachments,
           previewUrl: resp.urls.get,
           name: file.name,
-          size: file.size,
+          size: filesize(file.size),
           key: resp.key,
           xhr: xhr
         })

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -22,10 +22,12 @@
           <div class="editor-container"></div>
           <div class="comment-controls">
             <div class="comment-attachments"></div>
-            <input type="file" multiple>
+            <button class="comment-upload-button file-upload">
+              Upload Attachment<input type="file" multiple/>
+            </span>
           </div>
           <div class="comment-submission">
-            <button type="submit">Save</button>
+            <button class="comment-button" type="submit">Save</button>
             <div class="status"></div>
           </div>
         </form>
@@ -40,7 +42,7 @@
 
 <script id="comment-attachment-template" type="text/template">
   <div class="comment-attachment">
-    <span class="attachment-progress"><span>
+    <span class="attachment-progress"></span>
     <span class="attachment-filename"><%= name %></span>
     <span class="attachment-size"><%= size %></span>
     <span class="fa fa-times attachment-remove"></span>

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -39,11 +39,11 @@
 </section>
 
 <script id="comment-attachment-template" type="text/template">
-  <div>
-    <%= name %>
-    <%= size %>
-    <span class="attachment-remove">Remove</span>
+  <div class="comment-attachment">
     <span class="attachment-progress"><span>
+    <span class="attachment-filename"><%= name %></span>
+    <span class="attachment-size"><%= size %></span>
+    <span class="fa fa-times attachment-remove"></span>
   </div>
 </script>
 

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -20,10 +20,14 @@
         <div class="comment-context"></div>
         <form>
           <div class="editor-container"></div>
-          <div class="comment-attachments"></div>
-          <input type="file" multiple>
-          <button type="submit">Save</button>
-          <div class="status"></div>
+          <div class="comment-controls">
+            <div class="comment-attachments"></div>
+            <input type="file" multiple>
+          </div>
+          <div class="comment-submission">
+            <button type="submit">Save</button>
+            <div class="status"></div>
+          </div>
         </form>
       </div>
     </div>

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -27,7 +27,7 @@
             </span>
           </div>
           <div class="comment-submission">
-            <button class="comment-button" type="submit">Save</button>
+            <button class="comment-button" type="submit">Save Response</button>
             <div class="status"></div>
           </div>
         </form>


### PR DESCRIPTION
A few things to note/look for...
- I used a human readable filesize lib @jmcarp picked out but I don't necessarily know if I implemented it the preferred way.
- I had to refactor some CSS that styled all button elements under `#comment-review` because they were preventing the file upload from being styled.
- Are there any problems with that `<input>` styling hack in general?
- My text editor removed some whitespace on random stuff.
- Did I break tests by restructuring some of that attachment HTML? If so, I should probably learn how that all works and fix accordingly.
- There's going to be a PR in notice-and-comment that goes with this that you'll have to checkout at the same time to test or the buttons will be messed up. eregs/notice-and-comment#182


## Images 
<img width="696" alt="screen shot 2016-04-21 at 8 18 39 pm" src="https://cloud.githubusercontent.com/assets/776987/14728987/5128a39e-07ff-11e6-8b65-8960c470a1c8.png">

<img width="685" alt="screen shot 2016-04-21 at 8 18 50 pm" src="https://cloud.githubusercontent.com/assets/776987/14728989/512aeb68-07ff-11e6-8510-6deeeeb2c940.png">

<img width="682" alt="screen shot 2016-04-21 at 8 19 39 pm" src="https://cloud.githubusercontent.com/assets/776987/14728988/51295e38-07ff-11e6-8492-7588b441db26.png">