### PR TITLE
Trigger pane change on open search result.

### DIFF
--- a/regulations/static/regulations/js/source/views/main/search-results-view.js
+++ b/regulations/static/regulations/js/source/views/main/search-results-view.js
@@ -105,6 +105,7 @@ var SearchResultsView = ChildView.extend({
               scrollToId: $resultLink.data('linked-subsection')
             };
 
+            DrawerEvents.trigger('pane:change', 'table-of-contents');
             MainEvents.trigger('section:open', $resultLink.data('linked-section'), options, pageType);
         }
     }

--- a/regulations/templates/regulations/chrome.html
+++ b/regulations/templates/regulations/chrome.html
@@ -155,7 +155,7 @@
             <h3 class="toc-type">Search</h3>
         </div><!-- /.drawer-header -->
         <div class="drawer-content">
-            <form action="{% url 'chrome_search' reg_part %}" method="GET" role="search">
+            <form action="{% url 'chrome_search' reg_part %}" method="GET" role="search" data-doc-type="cfr">
                 <div class="search-box">
                     <input type="text" name="q" value="{{ q }}" id="search-input" title="Search term"/><button type="submit"><span class="cf-icon cf-icon-search"></span><strong class="icon-text">Search</strong></button>
                 </div><!--/.search-box-->


### PR DESCRIPTION
Bonus: also fixes drawer tab highlighting on opening cfr search results,
which appears to have been broken all along.

[Resolves https://github.com/eregs/notice-and-comment/issues/178]