### PR TITLE
Use consistent names in comment payload.

### DIFF
--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -74,9 +74,7 @@ var CommentReviewView = Backbone.View.extend({
   serialize: function() {
     // TODO(vrajmohan) Add other regs.gov fields
     return {
-        assembled_comment:  {
-            sections: comments.toJSON({docId: this.docId})
-        }
+      assembled_comment: comments.toJSON({docId: this.docId})
     };
   },
 

--- a/regulations/views/comment.py
+++ b/regulations/views/comment.py
@@ -67,7 +67,8 @@ def preview_comment(request):
     URL to GET the PDF.
     """
     body = json.loads(request.body.decode('utf-8'))
-    html = tasks.json_to_html(body)
+    sections = body.get('assembled_comment', [])
+    html = tasks.json_to_html(sections)
     key = '/'.join([settings.ATTACHMENT_PREVIEW_PREFIX, get_random_string(50)])
     s3 = tasks.make_s3_client()
     with tasks.html_to_pdf(html) as pdf:


### PR DESCRIPTION
Store comment sections as an array under the top-level
`assembled_comment` field in the comment preview and comment submit
payloads.

Tests to follow.