### PR TITLE
Add footer nav to preamble sections.

### DIFF
--- a/regulations/static/regulations/js/source/views/main/section-footer-view.js
+++ b/regulations/static/regulations/js/source/views/main/section-footer-view.js
@@ -21,9 +21,11 @@ var SectionFooterView = Backbone.View.extend({
 
     sendNavEvent: function(e) {
         e.preventDefault();
-        var sectionId = $(e.currentTarget).data('linked-section');
+        var $target = $(e.currentTarget);
+        var sectionId = $target.data('linked-section');
+        var pageType = $target.data('page-type') || 'reg-section';
 
-        MainEvents.trigger('section:open', sectionId, {}, 'reg-section');
+        MainEvents.trigger('section:open', sectionId, {}, pageType);
     },
 
     remove: function() {

--- a/regulations/templates/regulations/navigation.html
+++ b/regulations/templates/regulations/navigation.html
@@ -11,7 +11,7 @@
             <a href="{{ prev.url }}"
                class="navigation-link backward next-prev-link"
                data-linked-section="{{prev.section_id}}"
-               data-page-type="{{page_type}}"
+               data-page-type="{{navigation.page_type}}"
             ><span class="cf-icon cf-icon-left"></span><span class="next-prev-label">Previous section - </span>{{ prev.markup_prefix|safe }}{{prev.label}} </a> <span class="next-prev-title">{{prev.sub_label}}</span>
         </li>
 {% endwith %}
@@ -23,7 +23,7 @@
             <a href="{{ next.url }}"
                class="navigation-link forward next-prev-link"
                data-linked-section="{{next.section_id}}"
-               data-page-type="{{page_type}}"
+               data-page-type="{{navigation.page_type}}"
             ><span class="cf-icon cf-icon-right"></span><span class="next-prev-label">Next section - </span>{{ next.markup_prefix|safe }}{{next.label}}</a> <span class="next-prev-title">{{next.sub_label}}</span>
         </li>
 {% endwith %}

--- a/regulations/templates/regulations/navigation.html
+++ b/regulations/templates/regulations/navigation.html
@@ -11,6 +11,7 @@
             <a href="{{ prev.url }}"
                class="navigation-link backward next-prev-link"
                data-linked-section="{{prev.section_id}}"
+               data-page-type="{{page_type}}"
             ><span class="cf-icon cf-icon-left"></span><span class="next-prev-label">Previous section - </span>{{ prev.markup_prefix|safe }}{{prev.label}} </a> <span class="next-prev-title">{{prev.sub_label}}</span>
         </li>
 {% endwith %}
@@ -22,6 +23,7 @@
             <a href="{{ next.url }}"
                class="navigation-link forward next-prev-link"
                data-linked-section="{{next.section_id}}"
+               data-page-type="{{page_type}}"
             ><span class="cf-icon cf-icon-right"></span><span class="next-prev-label">Next section - </span>{{ next.markup_prefix|safe }}{{next.label}}</a> <span class="next-prev-title">{{next.sub_label}}</span>
         </li>
 {% endwith %}

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -11,6 +11,7 @@
     {% endif %}
 
     {% include "regulations/footnotes.html" %}
+    {% include "regulations/navigation.html" %}
   </div>
 
   <div id="preamble-write">

--- a/regulations/tests/views_preamble_tests.py
+++ b/regulations/tests/views_preamble_tests.py
@@ -1,8 +1,9 @@
+from mock import patch
 from unittest import TestCase
 
+from nose.tools import *  # noqa
 from django.http import Http404
 from django.test import RequestFactory
-from mock import patch
 
 from regulations.views import preamble
 
@@ -108,7 +109,11 @@ class PreambleToCTests(TestCase):
                         'label': ['abc', '123', 'I', 'A'],
                     }
                 ]
-            }
+            },
+            {
+                'title': 'l2',
+                'label': ['abc', '123', 'II'],
+            },
         ]
 
     def test_preamble_toc(self):
@@ -130,13 +135,31 @@ class PreambleToCTests(TestCase):
                             children=[],
                         )
                     ]
-                )
+                ),
+                preamble.PreambleSect(
+                    depth=1,
+                    title='l2',
+                    url='/preamble/abc/123#abc-123-II',
+                    full_id='abc-preamble-abc-123-II',
+                    children=[]
+                ),
             ],
         )
 
     def test_max_depth(self):
         toc = preamble.make_preamble_toc(self.nodes, max_depth=1)
         self.assertEqual(toc[0].children, [])
+
+    def test_navigation(self):
+        toc = preamble.make_preamble_toc(self.nodes)
+
+        nav = preamble.section_navigation('abc-preamble-abc-123-I', toc)
+        assert_equal(nav['next'].section_id, 'abc-preamble-abc-123-II')
+        assert_is_none(nav['previous'])
+
+        nav = preamble.section_navigation('abc-preamble-abc-123-II', toc)
+        assert_equal(nav['previous'].section_id, 'abc-preamble-abc-123-I')
+        assert_is_none(nav['next'])
 
 
 class CFRChangeToCTests(TestCase):

--- a/regulations/views/partial.py
+++ b/regulations/views/partial.py
@@ -55,8 +55,8 @@ class PartialSectionView(PartialView):
         if nav_sections:
             p_sect, n_sect = nav_sections
 
-            nav = {'previous': p_sect, 'next': n_sect}
-            return nav
+            return {'previous': p_sect, 'next': n_sect,
+                    'page_type': 'reg-section'}
 
     def transform_context(self, context, builder):
         child_of_root = builder.tree
@@ -69,7 +69,6 @@ class PartialSectionView(PartialView):
         context['tree'] = {'children': [child_of_root]}
         context['navigation'] = self.section_navigation(
             context['label_id'], context['version'])
-        context['page_type'] = 'reg-section'
 
         return context
 

--- a/regulations/views/partial.py
+++ b/regulations/views/partial.py
@@ -69,6 +69,7 @@ class PartialSectionView(PartialView):
         context['tree'] = {'children': [child_of_root]}
         context['navigation'] = self.section_navigation(
             context['label_id'], context['version'])
+        context['page_type'] = 'reg-section'
 
         return context
 


### PR DESCRIPTION
The implementation here is clumsy. Based on a conversation off-line, it sounds like @cmc333333 and I agree that doing much of this work in -parser would make sense longer-term, but this seemed like the quickest way to get the feature working. Famous last words.

<img width="1066" alt="screen shot 2016-04-22 at 5 52 10 pm" src="https://cloud.githubusercontent.com/assets/1633460/14755841/031273b0-08b3-11e6-86b3-bff85de820ad.png">
