### PR TITLE
changing <strong> to not force font-style

### DIFF
--- a/regulations/static/regulations/css/less/mixins.less
+++ b/regulations/static/regulations/css/less/mixins.less
@@ -1,5 +1,5 @@
 /*
-LESS Mixins 
+LESS Mixins
  ==========================================================================
 mixins.less contains any mixins to be used throughout the LESS files
 */
@@ -14,7 +14,6 @@ mixins.less contains any mixins to be used throughout the LESS files
 .font-bold {
     font-family: "Avenir Next Demi", Arial, sans-serif;
     font-weight: 600;
-    font-style: normal;
 }
 
 .font-italic {
@@ -30,7 +29,7 @@ mixins.less contains any mixins to be used throughout the LESS files
     &:extend(.font-bold);
     color: @mid_text;
     font-size: .875em; /* 12px / (26px * .875em) */
-    text-transform: uppercase;    
+    text-transform: uppercase;
 }
 
 /* Regulation nav (drawer) font styles */
@@ -79,7 +78,7 @@ mixins.less contains any mixins to be used throughout the LESS files
     font-size: 0.875em;
 }
 
-.next-prev-link-title-font {    
+.next-prev-link-title-font {
 }
 
 

--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -23,7 +23,7 @@ body {
 }
 
 strong {
-    font-weight: 600;
+  .font-bold;
 }
 
 /*  Default Headings

--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -23,7 +23,7 @@ body {
 }
 
 strong {
-    .font-bold;
+    font-weight: 600;
 }
 
 /*  Default Headings


### PR DESCRIPTION
referencing the .font-bold mixin applies a font-style: normal which doesn't allow things to be both **bold** and _italic_