### PR TITLE
Updating headers

### DIFF
--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -4,7 +4,7 @@
 
 {% if node.header %}
 <div class="node">
-  <h{{ node.list_level|add:"+3" }} class="section-header">{{ node.header | safe }}</h{{ node.list_level|add:"+3" }}>
+  <h{{ node.list_level|add:"+2" }} class="section-header">{{ node.header | safe }}</h{{ node.list_level|add:"+2" }}>
   {% if node.accepts_comments %}
     <div
         class="activate-write"


### PR DESCRIPTION
fixes eregs/notice-and-comment#188 (partially) 

After confirming with @jehlers it looks like all of our headers were 1 level higher than intended. This adjusts how they are generated. There will be another PR in eregs/notice-and-comment that addresses the spacing/margin around those headers.

