### PR TITLE
review screen responsification

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -430,15 +430,15 @@ a.comment-index-review {
   }
 
   .comment-content {
-    max-width: 480px;
+    max-width: 95%;
   }
 
   .edit-comment {
     color: @pacific;
     cursor: pointer;
     position: absolute;
-    right: 25px;
-    top: 20px;
+    right: 2%;
+    top: 0;
 
     .write-icon {
       fill: @pacific;
@@ -693,16 +693,31 @@ a.comment-index-review {
   }
 }
 
+// margins in .preamble-wrapper are overrides for things defined in .main-content
+// because the preamble doesn't use the right sidebar
+
 @media only screen and ( min-width: 780px ) {
   .preamble-wrapper {
     margin-right: 5%;
+    margin-left: 3%;
     padding-left: 35px;
+  }
+
+  #comment-review {
+    .comment-content {
+      max-width: 75%;
+    }
+    .edit-comment {
+      right: 2%;
+      top: 35px;
+    }
   }
 }
 
 @media only screen and ( min-width: 1100px ) {
   .preamble-wrapper {
     margin-right: 5%;
+    margin-left: 240px; /*240px; - offsets .panel */
     padding-left: 35px;
 
     // don't need max-width to account for a right sidebar

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -603,9 +603,6 @@ a.comment-index-review {
       right: 2%;
       top: 35px;
     }
-    .download-comment .details {
-      font-size: 12px;
-    }
   }
 }
 
@@ -803,5 +800,11 @@ a.comment-index-review {
       right: 0;
       top: 5px;
     }
+    .download-comment .details {
+      font-size: 12px;
+    }
+  }
+  .section-nav .previous {		
+    margin-left: -10px;
   }
 }

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -591,7 +591,7 @@ a.comment-index-review {
 @media only screen and ( min-width: 780px ) {
   .preamble-wrapper {
     margin-right: 5%;
-    margin-left: 40px; /*240px; - offsets collapsed .panel */
+    margin-left: 40px; /*40px; - offsets collapsed .panel */
     padding-left: 15px;
   }
 

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -100,7 +100,7 @@ comment.less contains styles related to commenting on sections
 }
 
 #preamble-write {
-  padding-left: 15px;
+  padding-left: 25px;
   width: 75%;
 }
 
@@ -388,6 +388,7 @@ a.comment-index-review {
 #comment-review {
   .font-regular;
   margin-bottom: 50px;
+  padding-left: 25px;
 
   h2, h3 {
     margin: 0.5em 0 0;
@@ -685,6 +686,8 @@ a.comment-index-review {
   }
 
   #comment-review {
+    padding-left: 0;
+
     .edit-comment {
       position: relative;
       right: 0;
@@ -699,8 +702,8 @@ a.comment-index-review {
 @media only screen and ( min-width: 780px ) {
   .preamble-wrapper {
     margin-right: 5%;
-    margin-left: 3%;
-    padding-left: 35px;
+    margin-left: 40px; /*240px; - offsets collapsed .panel */
+    padding-left: 15px;
   }
 
   #comment-review {
@@ -718,7 +721,7 @@ a.comment-index-review {
   .preamble-wrapper {
     margin-right: 5%;
     margin-left: 240px; /*240px; - offsets .panel */
-    padding-left: 35px;
+    padding-left: 15px;
 
     // don't need max-width to account for a right sidebar
     // so preamble text will fill the space when nav is minimized


### PR DESCRIPTION
fixes eregs/notice-and-comment#225

technically this touches on a few places other than just the review screen.

Sorry for the messy diffs. I really should've double checked pending PRs before starting this...

also: there's a known issue with some extra spacing in the tab title word's that get hidden in the mobile view. That style's in notice-and-comment and I'll have a PR that removes it.

![screen shot 2016-04-26 at 4 30 26 pm](https://cloud.githubusercontent.com/assets/776987/14835390/21f7c824-0bcf-11e6-822f-f973bd2719de.png)
![screen shot 2016-04-26 at 4 30 11 pm](https://cloud.githubusercontent.com/assets/776987/14835389/21f52948-0bcf-11e6-994e-1b6c85e08709.png)
![screen shot 2016-04-26 at 4 30 01 pm](https://cloud.githubusercontent.com/assets/776987/14835391/21fa8aa0-0bcf-11e6-81a7-0d46c8a5ee48.png)
