### PR TITLE
[WIP] Prototype custom form fields.

### DIFF
--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -66,10 +66,53 @@ var CommentReviewView = Backbone.View.extend({
     this.$content.html(html);
     this.findElms();
 
+    this.initTabs();
+    this.initDependencies();
+
     this.$form.find('[name="comments"]').val(JSON.stringify(commentData));
 
     this.preambleHeadView = new PreambleHeadView();
     CommentEvents.trigger('comment:writeTabOpen');
+  },
+
+  initTabs: function() {
+    function updateTabs(tab) {
+      $('[data-tab]').removeClass('current');
+      $('[data-tab="' + tab + '"]').addClass('current');
+      $('[data-tabs]').each(function(idx, elm) {
+        var $elm = $(elm);
+        var tabs = $elm.data('tabs');
+        if (tabs.indexOf(tab) !== -1) {
+          $elm.show();
+        } else {
+          $elm.hide();
+        }
+      });
+    }
+    var $tabs = $('[data-tab]');
+    updateTabs($tabs.eq(0).data('tab'));
+    $tabs.on('click', function() {
+      var tab = $(this).data('tab');
+      updateTabs(tab);
+    });
+  },
+
+  initDependencies: function() {
+    $('select[data-depends-on]').each(function(idx, elm) {
+      var $elm = $(elm);
+      var $dependsOn = $('[name="' + $elm.data('depends-on') + '"]');
+      var dependencies = $elm.data('dependencies');
+      function updateOptions() {
+        $elm.find('option[value]').remove();
+        var pairs = dependencies[$(this).val()] || [];
+        $.each(pairs, function(idx, pair) {
+          $elm.append('<option value="' + pair[0] + '">' + pair[1] + '</option>');
+        });
+        $elm.val(null);
+      }
+      updateOptions.apply($dependsOn);
+      $dependsOn.on('change', updateOptions);
+    });
   },
 
   preview: function() {

--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -76,10 +76,12 @@ var CommentReviewView = Backbone.View.extend({
   },
 
   initTabs: function() {
-    function updateTabs(tab) {
-      $('[data-tab]').removeClass('current');
-      $('[data-tab="' + tab + '"]').addClass('current');
-      $('[data-tabs]').each(function(idx, elm) {
+    function updateTabs(tab, tabSet) {
+      var tabSelector = '[data-tab="' + tab + '"]';
+      var setSelector = '[data-tab-set="' + tabSet + '"]';
+      $(setSelector).removeClass('current');
+      $(setSelector + tabSelector).addClass('current');
+      $(setSelector + '[data-tabs]').each(function(idx, elm) {
         var $elm = $(elm);
         var tabs = $elm.data('tabs');
         if (tabs.indexOf(tab) !== -1) {
@@ -90,10 +92,10 @@ var CommentReviewView = Backbone.View.extend({
       });
     }
     var $tabs = $('[data-tab]');
-    updateTabs($tabs.eq(0).data('tab'));
+    updateTabs($tabs.data('tab'), $tabs.data('tab-set'));
     $tabs.on('click', function() {
-      var tab = $(this).data('tab');
-      updateTabs(tab);
+      var $tab = $(this);
+      updateTabs($tab.data('tab'), $tab.data('tab-set'));
     });
   },
 
@@ -101,17 +103,18 @@ var CommentReviewView = Backbone.View.extend({
     $('select[data-depends-on]').each(function(idx, elm) {
       var $elm = $(elm);
       var $dependsOn = $('[name="' + $elm.data('depends-on') + '"]');
-      var dependencies = $elm.data('dependencies');
-      function updateOptions() {
+      var $options = $elm.find('option[value]').detach().clone();
+      function updateOptions(value) {
         $elm.find('option[value]').remove();
-        var pairs = dependencies[$(this).val()] || [];
-        $.each(pairs, function(idx, pair) {
-          $elm.append('<option value="' + pair[0] + '">' + pair[1] + '</option>');
-        });
+        $options.filter(function(idx, elm) {
+          return $(elm).data('dependency') === value;
+        }).appendTo($elm);
         $elm.val(null);
       }
       updateOptions.apply($dependsOn);
-      $dependsOn.on('change', updateOptions);
+      $dependsOn.on('change', function() {
+        updateOptions($(this).val());
+      });
     });
   },
 

--- a/regulations/templates/regulations/comment-review-chrome.html
+++ b/regulations/templates/regulations/comment-review-chrome.html
@@ -67,26 +67,7 @@
 
         <input type="hidden" name="comments" />
 
-        <div class="additional-info">
-          <h4>Include your information (Optional)</h4>
-
-          <fieldset>
-            <legend>Your name</legend>
-            <span>First and last name of the person submitting the comment.</span>
-            <input type="text" class="your-name">
-          </fieldset>
-
-          <fieldset>
-            <input type="checkbox" class="org-submit">
-            <label for="org-submit">I am submitting on behalf of an organization.</label>
-          </fieldset>
-
-          <fieldset>
-            <input type="checkbox" class="agency-submit">
-            <label for="agency-submit">I am submitting on behalf of a government agency.</label>
-          </fieldset>
-
-        </div>
+        {% include 'regulations/comment-additional-info.html' %}
 
         <div class="statement">
           <p>You are filling a document into an official docket.


### PR DESCRIPTION
This allows downstream installs to override custom form fields and implements very basic tab groups and interdependent fields. Note: because we redraw most of the comment review page on render, this patch rebuilds the required event listeners after each render. I think this is inelegant, but fixing would involve a larger refactor of this page that I'd like to talk about in a separate issue.

As usual, I haven't tried to style this--looking for help from @xtine and @donjo once we verify that this works as expected.

![5tsnbrkfd6](https://cloud.githubusercontent.com/assets/1633460/14864019/2f0c953c-0c86-11e6-87da-f4f9ee73e375.gif)
