### PR TITLE
Clean up #300 post-merge.

### DIFF
--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -98,7 +98,7 @@ var CommentReviewView = Backbone.View.extend({
         }).appendTo($elm);
         $elm.val(null);
       }
-      updateOptions.apply($dependsOn);
+      updateOptions($dependsOn.val());
       $dependsOn.on('change', function() {
         updateOptions($(this).val());
       });


### PR DESCRIPTION
* Add empty additional info template
* Fix invocation of dependencies helper

h/t @cmc333333

BTW, the errant `apply` was a leftover from the first commit on #300, where `updateOptions` was meant to be bound to a jquery object, since its main use is as a callback to an event listener. Which I decided against--halfheartedly, I guess.