### PR TITLE
adding whitespace below the footer

### DIFF
--- a/regulations/static/regulations/css/less/module/footer.less
+++ b/regulations/static/regulations/css/less/module/footer.less
@@ -82,6 +82,10 @@ Next/Previous Links
     margin-top: 50px;
 }
 
+.footer-nav {
+  margin-bottom: 150px;
+}
+
 /* styles for both the next and previous blocks */
 .next-prev {
     border-top: 2px solid @medium_gray;
@@ -116,7 +120,7 @@ Next/Previous Links
     .cf-icon-right {
         font-size: 0.875em;
         margin-right: -15px;
-        margin-top: 6px; 
+        margin-top: 6px;
         float: right;
     }
 }

--- a/regulations/static/regulations/css/less/module/footer.less
+++ b/regulations/static/regulations/css/less/module/footer.less
@@ -160,6 +160,10 @@ Small Screens
         }
     }
 
+    .footer-nav {
+      margin-bottom: 50px;
+    }
+
     .application-footer {
         .title-logo {
             display: block;
@@ -178,6 +182,10 @@ Small Screens
 
     .section-nav {
         margin-top: 1.5em;
+    }
+
+    .footer-nav {
+      margin-bottom: 60px;
     }
 
     .next-prev {

--- a/regulations/templates/regulations/navigation.html
+++ b/regulations/templates/regulations/navigation.html
@@ -3,7 +3,7 @@
 {% endcomment %}
 
 {% if navigation %}
-<nav class="section-nav" role="navigation">
+<nav class="section-nav footer-nav" role="navigation">
     <ul>
 {% if navigation.previous %}
 {% with prev=navigation.previous %}


### PR DESCRIPTION
full-page content pushed the next/previous links right up against the bottom of the screen

![screen shot 2016-04-28 at 2 17 18 pm](https://cloud.githubusercontent.com/assets/776987/14898371/fbc3dd4a-0d4b-11e6-944f-6f54dd4c30ab.png)
⬇️ 
![screen shot 2016-04-28 at 2 16 53 pm](https://cloud.githubusercontent.com/assets/776987/14898370/fbc217e4-0d4b-11e6-87fc-af69905ee24e.png)
