### PR TITLE
cleaning up extract background highlight

### DIFF
--- a/regulations/static/regulations/css/less/module/extract.less
+++ b/regulations/static/regulations/css/less/module/extract.less
@@ -1,6 +1,8 @@
-.extract {
+// Targets the inner paragraph because the node div has right padding that stretches out the bg color
+
+.extract > div > p {
     background-color: @bg_gray;
-    padding: 0.125em .625em;
+    padding: 0.5em 1em;
     margin-bottom: 1em;
     border-bottom: 0px;
 }

--- a/regulations/static/regulations/css/less/module/extract.less
+++ b/regulations/static/regulations/css/less/module/extract.less
@@ -1,8 +1,12 @@
 // Targets the inner paragraph because the node div has right padding that stretches out the bg color
 
+.extract > div {
+  margin-bottom: 1em;
+}
+
 .extract > div > p {
     background-color: @bg_gray;
     padding: 0.5em 1em;
-    margin-bottom: 1em;
+    margin-bottom: 0em;
     border-bottom: 0px;
 }


### PR DESCRIPTION
Cleaning this up so it doesn't go the full width of the screen due to node

Not sure if this is the best way to style this.

![screen shot 2016-04-28 at 2 42 59 pm](https://cloud.githubusercontent.com/assets/776987/14899346/3c32da34-0d51-11e6-9859-1be5c7e723ec.png)
