### PR TITLE
Redirect to preamble on confirm GET.

### DIFF
--- a/regulations/tests/views_preamble_tests.py
+++ b/regulations/tests/views_preamble_tests.py
@@ -79,6 +79,21 @@ class PreambleViewTests(TestCase):
             '4',
         )
 
+    @patch('regulations.views.preamble.CFRChangeToC')
+    @patch('regulations.generator.generator.api_reader')
+    @patch('regulations.views.preamble.ApiReader')
+    def test_get_top_level_redirect(self, ApiReader, api_reader, CFRChangeToC):
+        ApiReader.return_value.preamble.return_value = self._mock_preamble
+        api_reader.ApiReader.return_value.layer.return_value = {
+            '1-c-x': ['something']
+        }
+        view = preamble.PreambleView.as_view()
+
+        path = '/preamble/1'
+        response = view(RequestFactory().get(path), paragraphs='1')
+        assert_equal(response.status_code, 302)
+        assert_equal(response.get('Location'), '/preamble/1/c')
+
     @patch('regulations.views.preamble.ApiReader')
     def test_get_404(self, ApiReader):
         """When a requested doc is not present, we should return a 404"""

--- a/regulations/views/comment.py
+++ b/regulations/views/comment.py
@@ -8,6 +8,7 @@ import requests
 from django.conf import settings
 from django.core.cache import caches
 from django.http import JsonResponse
+from django.shortcuts import redirect
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 from django.template.response import TemplateResponse
@@ -82,6 +83,9 @@ regs_gov_fmt = 'https://www.regulations.gov/#!documentDetail;D={document}'
 
 
 class SubmitCommentView(View):
+
+    def get(self, request, doc_number):
+        return redirect('chrome_preamble', paragraphs=doc_number)
 
     def post(self, request, doc_number):
         form_data = {


### PR DESCRIPTION
This redirects the confirm url (e.g. `/comments/comment/2016_02749`) to the corresponding preamble url (`/preamble/2016_02749`). Just to confirm--something *is* going to live at that url, right? If not, we can redirect to the first preamble section, or the home page.