### PR TITLE
reducing link width in closed ToC so the full border shows

### DIFF
--- a/regulations/static/regulations/css/less/base-variables.less
+++ b/regulations/static/regulations/css/less/base-variables.less
@@ -43,3 +43,9 @@ variables.less contains all theme variable / variable overrides
 */
 
 @body_font: Georgia, serif;
+
+/*
+Layout Variables
+*/
+
+@closed_drawer_width: 40px;

--- a/regulations/static/regulations/css/less/module/drawer.less
+++ b/regulations/static/regulations/css/less/module/drawer.less
@@ -187,7 +187,7 @@ currently these are TOC, History, and Search
     .close & {
         display: block;
         border-right: none;
-        width: 40px;
+        width: 39px;
     }
 
     /* Fall back to PNG images for drawer icons when @font-face isn't supported */

--- a/regulations/static/regulations/css/less/module/drawer.less
+++ b/regulations/static/regulations/css/less/module/drawer.less
@@ -119,7 +119,7 @@ Panel Slide Button
     display: block;
     height: 34px; /* match height of main header */
     line-height: 34px;
-    width: 40px;
+    width: @closed_drawer_width;
     float: right;
     cursor: pointer;
     text-align: center;
@@ -187,7 +187,7 @@ currently these are TOC, History, and Search
     .close & {
         display: block;
         border-right: none;
-        width: 39px;
+        width: @closed_drawer_width - 1;
     }
 
     /* Fall back to PNG images for drawer icons when @font-face isn't supported */
@@ -236,7 +236,7 @@ currently these are TOC, History, and Search
 
     .close & {
         position: absolute;
-        width: 40px;
+        width: @closed_drawer_width;
         top: 33px;
         border-top: 1px solid @medium_gray;
         right: 0;


### PR DESCRIPTION
The width of the ToC items was obscuring some of the border when the ToC was in the "closed" position.

![screen shot 2016-04-29 at 11 03 13 am](https://cloud.githubusercontent.com/assets/776987/14922418/1dae871e-0dfd-11e6-844b-3bc02b01ba50.png)

to 

![screen shot 2016-04-29 at 11 09 16 am](https://cloud.githubusercontent.com/assets/776987/14922426/252395f2-0dfd-11e6-9362-cf65d12e19dd.png)
