### PR TITLE
Sort comments by label

### DIFF
--- a/regulations/static/regulations/js/source/collections/comment-collection.js
+++ b/regulations/static/regulations/js/source/collections/comment-collection.js
@@ -26,6 +26,7 @@ var CommentCollection = Backbone.Collection.extend({
 });
 
 var comments = new CommentCollection();
+comments.comparator = 'label';
 comments.fetch();
 
 module.exports = comments;


### PR DESCRIPTION
Although this is a far cry from what is really needed, ie, sorting in
the notice's document order, this small change makes it nicer
than the current behavior.