### PR TITLE
Fetch field options from regs.gov.

### DIFF
--- a/regulations/docket.py
+++ b/regulations/docket.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 import logging
 
 import six
@@ -7,25 +6,18 @@ import requests
 from django.conf import settings
 from django.core.cache import caches
 
-Field = namedtuple('Field', 'max_length, required')
-
 logger = logging.getLogger(__name__)
 
+cache = caches['regs_gov_cache']
 
-def get_document_metadata(document_id):
-    """ Retrieve document metadata from regulations.gov. """
-    logger.debug("Getting docket metadata")
-    response = requests.get(
-        settings.REGS_GOV_API_URL,
-        params={'D': document_id},
-        headers={'X-Api-Key': settings.REGS_GOV_API_KEY}
-    )
-    if response.status_code == requests.codes.ok:
-        return response.json()
-    else:
-        logger.error("Failed to lookup regulations.gov: {}",
-                     response.status_code, response.text)
+
+def fetch(url, **kwargs):
+    kwargs['headers'] = kwargs.get(
+        'headers', {'X-Api-Key': settings.REGS_GOV_API_KEY})
+    response = requests.get(url, **kwargs)
+    if response.status_code != requests.codes.ok:
         response.raise_for_status()
+    return response.json()
 
 
 def get_document_fields(document_id):
@@ -33,20 +25,40 @@ def get_document_fields(document_id):
         Use a cache as the data hardly ever changes.
         We ignore the 'general_comment' field as it has special treatment.
     """
-    cache = caches['regs_gov_cache']
-    cache_key = document_id
-    fields = cache.get(cache_key)
+    fields = cache.get(document_id)
+    if fields is not None:
+        return fields
 
-    if fields is None:
-        document_metadata = get_document_metadata(document_id)
-        fields = {
-            field['attributeName']: Field(field['maxLength'],
-                                          field['required'])
-            for field in document_metadata['fieldList']
-            if field['attributeName'] != 'general_comment'
-        }
-        cache.set(cache_key, fields)
+    metadata = fetch(settings.REGS_GOV_API_URL, params={'D': document_id})
+    fields = {
+        field['attributeName']: field
+        for field in metadata['fieldList']
+        if field['attributeName'] != 'general_comment'
+    }
+
+    add_options(fields)
+    add_dependent_options(fields)
+
+    cache.set(document_id, fields)
     return fields
+
+
+def add_options(fields):
+    """Augment fields with options."""
+    for name, field in fields.items():
+        if 'lookupUrl' in field and 'dependsOn' not in field:
+            data = fetch(field['lookupUrl'])
+            field['options'] = data['list']
+
+
+def add_dependent_options(fields):
+    """Augment fields with dependency-contingent options."""
+    for name, field in fields.items():
+        if 'dependsOn' in field and 'lookupUrl' in field:
+            field['options'] = {}
+            for option in fields[field['dependsOn']]['options']:
+                data = fetch(field['lookupUrl'] + option['value'])
+                field['options'][option['value']] = data.get('list', [])
 
 
 def sanitize_fields(body):
@@ -57,11 +69,11 @@ def sanitize_fields(body):
     """
     document_fields = get_document_fields(settings.COMMENT_DOCUMENT_ID)
     for name, field in six.iteritems(document_fields):
-        if field.required and name not in body:
+        if field['required'] and name not in body:
             return False, "Field {} is required".format(name)
-        if name in body and len(body[name]) > field.max_length:
-            return False, "Field {} exceeds expected length of {}".format(
-                name, field.max_length)
+        if name in body and len(body[name]) > field['max_length']:
+            return False, "Field {} exceeds maximum length of {}".format(
+                name, field['max_length'])
 
     # Remove extra fields if any, other than 'assembled_comment'
     extra_fields = [field for field in body if field not in document_fields]

--- a/regulations/docket.py
+++ b/regulations/docket.py
@@ -36,25 +36,30 @@ def get_document_fields(document_id):
         if field['attributeName'] != 'general_comment'
     }
 
-    add_options(fields)
-    add_dependent_options(fields)
+    add_picklist_options(fields)
+    add_combo_options(fields)
 
     cache.set(document_id, fields)
     return fields
 
 
-def add_options(fields):
-    """Augment fields with options."""
+def add_picklist_options(fields):
+    """Augment list fields with options. Adds a list of options to each field
+    of type "picklist".
+    """
     for name, field in fields.items():
-        if 'lookupUrl' in field and 'dependsOn' not in field:
+        if field['uiControl'] == 'picklist':
             data = fetch(field['lookupUrl'])
             field['options'] = data['list']
 
 
-def add_dependent_options(fields):
-    """Augment fields with dependency-contingent options."""
+def add_combo_options(fields):
+    """Augment combo fields with dependency-contingent options. Adds a dict
+    mapping contingent values to lists of options to each field of type
+    "combo".
+    """
     for name, field in fields.items():
-        if 'dependsOn' in field and 'lookupUrl' in field:
+        if field['uiControl'] == 'combo':
             field['options'] = {}
             for option in fields[field['dependsOn']]['options']:
                 data = fetch(field['lookupUrl'] + option['value'])

--- a/regulations/tests/sanitize_fields_tests.py
+++ b/regulations/tests/sanitize_fields_tests.py
@@ -2,7 +2,7 @@
 from mock import patch
 from unittest import TestCase
 
-from regulations.docket import sanitize_fields, Field
+from regulations.docket import sanitize_fields
 
 
 class SanitizeFieldsTest(TestCase):
@@ -11,8 +11,8 @@ class SanitizeFieldsTest(TestCase):
             'regulations.docket.get_document_fields')
         mock_object = self.patch_document_fields.start()
         mock_object.return_value = {
-            "required_field": Field(10, True),
-            "optional_field": Field(10, False),
+            'required_field': {'max_length': 10, 'required': True},
+            'optional_field': {'max_length': 10, 'required': False},
         }
 
     def tearDown(self):
@@ -56,5 +56,5 @@ class SanitizeFieldsTest(TestCase):
         }
         valid, message = sanitize_fields(test_body)
         self.assertFalse(valid)
-        self.assertEqual("Field required_field exceeds expected length of 10",
+        self.assertEqual("Field required_field exceeds maximum length of 10",
                          message)

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -15,6 +15,7 @@ from django.core.urlresolvers import reverse
 from django.template.response import TemplateResponse
 from django.views.generic.base import View
 
+from regulations import docket
 from regulations.generator.api_reader import ApiReader
 from regulations.generator.generator import LayerCreator
 from regulations.generator.html_builder import (
@@ -377,6 +378,8 @@ class PrepareCommentView(View):
         context.update(generate_html_tree(context['preamble'], request,
                                           id_prefix=[doc_number, 'preamble']))
         context['comment_mode'] = 'write'
+        context['comment_fields'] = docket.get_document_fields(
+            settings.COMMENT_DOCUMENT_ID)
         template = 'regulations/comment-review-chrome.html'
 
         return TemplateResponse(request=request, template=template,


### PR DESCRIPTION
This patch fetches options and dependency-contingent options for comment
fields from the regs.gov api. Field options are added to the template
context so that template overrides can access them if needed. Note: as
discussed with @cmc333333 and @vrajmohan, it would make sense to fetch
field metadata once in -parser instead; I'm proposing this change in the
interest of getting something working quickly.