### PR TITLE
[WIP] Sort comments

### DIFF
--- a/regulations/generator/layers/diff_applier.py
+++ b/regulations/generator/layers/diff_applier.py
@@ -83,7 +83,7 @@ class DiffApplier(object):
         return [lo for lo in label_ops if not self.has_moved(lo, seen_count)]
 
     def add_nodes_to_tree(self, original, adds):
-        """ Add all the nodes from new_nodes into the original tree. """
+        """ Add all the nodes from adds into the original tree. """
         tree_hash = tree_builder.build_tree_hash(original)
         for node in tree_hash.values():
             self.set_child_labels(node)

--- a/regulations/generator/layers/diff_applier.py
+++ b/regulations/generator/layers/diff_applier.py
@@ -88,6 +88,9 @@ class DiffApplier(object):
         for node in tree_hash.values():
             self.set_child_labels(node)
 
+        # We need this copy as we are mutating the queue below
+        adds_queue_copy = adds.queue[:]
+
         for label, node in adds.queue:
             p_label = '-'.join(tree_builder.parent_label(node))
             if tree_builder.parent_in_tree(p_label, tree_hash):
@@ -99,6 +102,8 @@ class DiffApplier(object):
                     tree_builder.add_child(parent[1], node)
                 else:
                     original.update(node)
+
+        assign_preorder(original, adds_queue_copy)
 
     def is_child_of_requested(self, label):
         """ Return true if the label is a child of the requested label.  """
@@ -182,3 +187,22 @@ class DiffApplier(object):
                 text_diffs = self.diff[label][component]
                 return self.apply_diff_changes(original, text_diffs)
         return original
+
+
+def assign_preorder(original, adds_queue):
+    """
+        Entire nodes that were added in the diff will not have their
+        preorder attribute set. This function sets the preorder for these nodes
+        by appending the relative position of these nodes (among their
+        siblings) to the parent's preorder. E.g., if node n was added as the
+        5th child of node p (whose preorder is 263), n will be assigned a
+        preorder of [263, 5].
+    """
+    tree_hash = tree_builder.build_tree_hash(original)
+    modified_parents_labels = ['-'.join(tree_builder.parent_label(node))
+                               for _, node in adds_queue]
+    for parent_label in modified_parents_labels:
+        parent_node = tree_hash[parent_label]
+        for index, child in enumerate(parent_node['children'], 1):
+            if 'preorder' not in child:
+                child['preorder'] = parent_node['preorder'] + [index]

--- a/regulations/static/regulations/js/source/collections/comment-collection.js
+++ b/regulations/static/regulations/js/source/collections/comment-collection.js
@@ -5,26 +5,10 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 Backbone.LocalStorage = require('backbone.localstorage');
 
-var CommentModel = require('../models/comment-model');
-
-var commentComparator = function(first, second) {
-    var returnValue;
-    if (first.get("tocId") < second.get("tocId")) {
-        returnValue = -1;
-    } else if (first.get("tocId") > second.get("tocId")) {
-        returnValue = 1;
-    } else if (first.get("indexes") < second.get("indexes")) {
-        returnValue = -1;
-    } else if (first.get("indexes") > second.get("indexes")) {
-        returnValue = 1;
-    } else {
-    returnValue = 0;
-    }
-    return returnValue;
-}
+var comment_model = require('../models/comment-model');
 
 var CommentCollection = Backbone.Collection.extend({
-  model: CommentModel,
+  model: comment_model.CommentModel,
   localStorage: new Backbone.LocalStorage('eregsnc'),
 
   filter: function(docId) {
@@ -40,7 +24,7 @@ var CommentCollection = Backbone.Collection.extend({
     });
   },
 
-  comparator: commentComparator
+  comparator: comment_model.commentComparator
 });
 
 var comments = new CommentCollection();

--- a/regulations/static/regulations/js/source/collections/comment-collection.js
+++ b/regulations/static/regulations/js/source/collections/comment-collection.js
@@ -7,6 +7,22 @@ Backbone.LocalStorage = require('backbone.localstorage');
 
 var CommentModel = require('../models/comment-model');
 
+var commentComparator = function(first, second) {
+    var returnValue;
+    if (first.get("tocId") < second.get("tocId")) {
+        returnValue = -1;
+    } else if (first.get("tocId") > second.get("tocId")) {
+        returnValue = 1;
+    } else if (first.get("indexes") < second.get("indexes")) {
+        returnValue = -1;
+    } else if (first.get("indexes") > second.get("indexes")) {
+        returnValue = 1;
+    } else {
+    returnValue = 0;
+    }
+    return returnValue;
+}
+
 var CommentCollection = Backbone.Collection.extend({
   model: CommentModel,
   localStorage: new Backbone.LocalStorage('eregsnc'),
@@ -22,11 +38,12 @@ var CommentCollection = Backbone.Collection.extend({
     return _.map(models, function(model) {
       return model.toJSON(options);
     });
-  }
+  },
+
+  comparator: commentComparator
 });
 
 var comments = new CommentCollection();
-comments.comparator = 'label';
 comments.fetch();
 
 module.exports = comments;

--- a/regulations/static/regulations/js/source/models/comment-model.js
+++ b/regulations/static/regulations/js/source/models/comment-model.js
@@ -6,18 +6,19 @@ var Backbone = require('backbone');
 var comment_model = Backbone.Model.extend({
   defaults: {
     docId: '',
+    tocId: '',
     label: '',
     comment: '',
     commentHtml: '',
     files: [],
-    indexes: []
+    preorder: []
   }
 });
 
-var index_comparator = function(first, second) {
-    var l = Math.max(first.length, second.length)
+var int_array_comparator = function(first, second) {
+    var max_length = Math.max(first.length, second.length)
 
-    for (var i = 0; i < l; i++) {
+    for (var i = 0; i < max_length; i++) {
         if (first[i] === undefined) {
             return -1;
         } else if (second[i] === undefined) {
@@ -32,12 +33,17 @@ var index_comparator = function(first, second) {
 };
 
 var comment_comparator = function(first, second) {
-    if (first.get('tocId') < second.get('tocId')) {
+    /* The preamble comes before the CFR changes.
+     * Within the preamble or CFR part, sorting is by preorder.
+     */
+    var first_part = first.get('tocId').split('-')[1]
+    var second_part = second.get('tocId').split('-')[1]
+    if (first_part == second_part) {
+        return int_array_comparator(first.get('preorder'), second.get('preorder'));
+    } else if (first_part == 'preamble') {
         return -1;
-    } else if (first.get('tocId') > second.get('tocId')) {
-        return 1;
     } else {
-        return index_comparator(first.get('indexes'), second.get('indexes'));
+        return 1;
     }
 };
 

--- a/regulations/static/regulations/js/source/models/comment-model.js
+++ b/regulations/static/regulations/js/source/models/comment-model.js
@@ -9,21 +9,35 @@ var comment_model = Backbone.Model.extend({
     label: '',
     comment: '',
     commentHtml: '',
-    files: []
+    files: [],
+    indexes: []
   }
 });
+
+var index_comparator = function(first, second) {
+    var l = Math.max(first.length, second.length)
+
+    for (var i = 0; i < l; i++) {
+        if (first[i] === undefined) {
+            return -1;
+        } else if (second[i] === undefined) {
+            return 1;
+        } else if (first[i] < second[i]) {
+            return -1;
+        } else if (first[i] > second[i]) {
+            return 1;
+        }
+    }
+    return 0;
+};
 
 var comment_comparator = function(first, second) {
     if (first.get('tocId') < second.get('tocId')) {
         return -1;
     } else if (first.get('tocId') > second.get('tocId')) {
         return 1;
-    } else if (first.get('indexes') < second.get('indexes')) {
-        return -1;
-    } else if (first.get('indexes') > second.get('indexes')) {
-        return 1;
     } else {
-        return 0;
+        return index_comparator(first.get('indexes'), second.get('indexes'));
     }
 };
 

--- a/regulations/static/regulations/js/source/models/comment-model.js
+++ b/regulations/static/regulations/js/source/models/comment-model.js
@@ -3,7 +3,7 @@
 var $ = require('jquery');
 var Backbone = require('backbone');
 
-module.exports = Backbone.Model.extend({
+var comment_model = Backbone.Model.extend({
   defaults: {
     docId: '',
     label: '',
@@ -12,3 +12,22 @@ module.exports = Backbone.Model.extend({
     files: []
   }
 });
+
+var comment_comparator = function(first, second) {
+    if (first.get('tocId') < second.get('tocId')) {
+        return -1;
+    } else if (first.get('tocId') > second.get('tocId')) {
+        return 1;
+    } else if (first.get('indexes') < second.get('indexes')) {
+        return -1;
+    } else if (first.get('indexes') > second.get('indexes')) {
+        return 1;
+    } else {
+        return 0;
+    }
+};
+
+module.exports = {
+    CommentModel: comment_model,
+    commentComparator: comment_comparator
+};

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -80,14 +80,14 @@ var CommentView = Backbone.View.extend({
     this.listenTo(CommentEvents, 'comment:target', this.target);
     this.listenTo(CommentEvents, 'attachment:remove', this.clearAttachment);
 
-    this.setSection(options.section, options.tocId, options.label);
+    this.setSection(options.section, options.tocId, options.indexes, options.label);
   },
 
-  setSection: function(section, tocId, label, blank) {
+  setSection: function(section, tocId, indexes, label, blank) {
     if (this.model) {
       this.stopListening(this.model);
     }
-    var options = {id: section, tocId: tocId, label: label, docId: this.options.docId};
+    var options = {id: section, tocId: tocId, indexes: indexes, label: label, docId: this.options.docId};
     this.model = blank ?
       new CommentModel(options) :
       comments.get(section) || new CommentModel(options);
@@ -96,7 +96,7 @@ var CommentView = Backbone.View.extend({
   },
 
   target: function(options) {
-    this.setSection(options.section, options.tocId, options.label);
+    this.setSection(options.section, options.tocId, options.indexes, options.label);
     this.$context.empty();
     if (options.$parent) {
       var label = options.label;

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -13,7 +13,7 @@ require('prosemirror/dist/markdown');
 
 var MainEvents = require('../../events/main-events');
 var DrawerEvents = require('../../events/drawer-events');
-var CommentModel = require('../../models/comment-model');
+var CommentModel = require('../../models/comment-model').CommentModel;
 var CommentEvents = require('../../events/comment-events');
 var AttachmentView = require('../../views/comment/attachment-view');
 var comments = require('../../collections/comment-collection');

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -80,14 +80,14 @@ var CommentView = Backbone.View.extend({
     this.listenTo(CommentEvents, 'comment:target', this.target);
     this.listenTo(CommentEvents, 'attachment:remove', this.clearAttachment);
 
-    this.setSection(options.section, options.tocId, options.indexes, options.label);
+    this.setSection(options.section, options.tocId, options.preorder, options.label);
   },
 
-  setSection: function(section, tocId, indexes, label, blank) {
+  setSection: function(section, tocId, preorder, label, blank) {
     if (this.model) {
       this.stopListening(this.model);
     }
-    var options = {id: section, tocId: tocId, indexes: indexes, label: label, docId: this.options.docId};
+    var options = {id: section, tocId: tocId, preorder: preorder, label: label, docId: this.options.docId};
     this.model = blank ?
       new CommentModel(options) :
       comments.get(section) || new CommentModel(options);
@@ -96,7 +96,7 @@ var CommentView = Backbone.View.extend({
   },
 
   target: function(options) {
-    this.setSection(options.section, options.tocId, options.indexes, options.label);
+    this.setSection(options.section, options.tocId, options.preorder, options.label);
     this.$context.empty();
     if (options.$parent) {
       var label = options.label;

--- a/regulations/static/regulations/js/source/views/main/preamble-view.js
+++ b/regulations/static/regulations/js/source/views/main/preamble-view.js
@@ -65,6 +65,7 @@ var PreambleView = ChildView.extend({
     this.write(
       $dataTarget.data('section'),
       $section.data('toc-id'),
+      $dataTarget.data('indexes'),
       $dataTarget.data('label'),
       $section
     );
@@ -78,12 +79,13 @@ var PreambleView = ChildView.extend({
     this.write(
       $section.find('.activate-write').data('section'),
       $section.data('toc-id'),
+      $section.data('indexes'),
       $section.find('.activate-write').data('label'),
       $section
     );
   },
 
-  write: function(section, tocId, label, $parent) {
+  write: function(section, tocId, indexes, label, $parent) {
     this.mode = 'write';
     $parent = $parent.clone();
     $parent.find('.activate-write').remove();
@@ -91,6 +93,7 @@ var PreambleView = ChildView.extend({
     CommentEvents.trigger('comment:target', {
       section: section,
       tocId: tocId,
+      indexes: indexes,
       label: label,
       $parent: $parent
     });

--- a/regulations/static/regulations/js/source/views/main/preamble-view.js
+++ b/regulations/static/regulations/js/source/views/main/preamble-view.js
@@ -65,7 +65,7 @@ var PreambleView = ChildView.extend({
     this.write(
       $dataTarget.data('section'),
       $section.data('toc-id'),
-      $dataTarget.data('indexes'),
+      $dataTarget.data('preorder'),
       $dataTarget.data('label'),
       $section
     );
@@ -79,13 +79,13 @@ var PreambleView = ChildView.extend({
     this.write(
       $section.find('.activate-write').data('section'),
       $section.data('toc-id'),
-      $section.data('indexes'),
+      $section.data('preorder'),
       $section.find('.activate-write').data('label'),
       $section
     );
   },
 
-  write: function(section, tocId, indexes, label, $parent) {
+  write: function(section, tocId, preorder, label, $parent) {
     this.mode = 'write';
     $parent = $parent.clone();
     $parent.find('.activate-write').remove();
@@ -93,7 +93,7 @@ var PreambleView = ChildView.extend({
     CommentEvents.trigger('comment:target', {
       section: section,
       tocId: tocId,
-      indexes: indexes,
+      preorder: preorder,
       label: label,
       $parent: $parent
     });

--- a/regulations/static/regulations/js/unittests/specs/collections/comment_collection.js
+++ b/regulations/static/regulations/js/unittests/specs/collections/comment_collection.js
@@ -29,9 +29,15 @@ describe('CommentCollection', function() {
       assert.equal(-1, commentComparator(comment1, comment2));
   });
 
-  it('sorts by indexes of different lengths when tocIds are equal', function() {
+  it('handles indexes of different lengths when sorting by indexes', function() {
       var comment1 = new CommentModel({tocId: "TocId", indexes: [0, 3, 2, 1]});
       var comment2 = new CommentModel({tocId: "TocId", indexes: [0, 3, 3]});
+      assert.equal(-1, commentComparator(comment1, comment2));
+  });
+
+  it('sorts by index magnitude as opposed to lexical sorting when sorting by indexes ', function() {
+      var comment1 = new CommentModel({tocId: "TocId", indexes: [0, 3]});
+      var comment2 = new CommentModel({tocId: "TocId", indexes: [0, 20]});
       assert.equal(-1, commentComparator(comment1, comment2));
   });
 });

--- a/regulations/static/regulations/js/unittests/specs/collections/comment_collection.js
+++ b/regulations/static/regulations/js/unittests/specs/collections/comment_collection.js
@@ -17,27 +17,33 @@ describe('CommentCollection', function() {
 
   });
 
-  it('sorts by tocId', function() {
-      var comment1 = new CommentModel({tocId: "TocId 1", indexes: []});
-      var comment2 = new CommentModel({tocId: "TocId 2", indexes: []});
+  it('sorts preamble before CFR', function() {
+      var comment1 = new CommentModel({tocId: "toc-preamble-foo", preorder: [2]});
+      var comment2 = new CommentModel({tocId: "toc-cfr-foo", preorder: [1]});
       assert.equal(-1, commentComparator(comment1, comment2));
   });
 
-  it('sorts by indexes when tocIds are equal', function() {
-      var comment1 = new CommentModel({tocId: "TocId", indexes: [0, 1]});
-      var comment2 = new CommentModel({tocId: "TocId", indexes: [0, 2]});
+  it('sorts by preorder within preamble', function() {
+      var comment1 = new CommentModel({tocId: "toc-preamble-bfoo", preorder: [0, 1]});
+      var comment2 = new CommentModel({tocId: "toc-preamble-afoo", preorder: [0, 2]});
       assert.equal(-1, commentComparator(comment1, comment2));
   });
 
-  it('handles indexes of different lengths when sorting by indexes', function() {
-      var comment1 = new CommentModel({tocId: "TocId", indexes: [0, 3, 2, 1]});
-      var comment2 = new CommentModel({tocId: "TocId", indexes: [0, 3, 3]});
+  it('sorts by preorder within CFR', function() {
+      var comment1 = new CommentModel({tocId: "toc-CFR-bfoo", preorder: [0, 1]});
+      var comment2 = new CommentModel({tocId: "toc-CFR-afoo", preorder: [0, 2]});
       assert.equal(-1, commentComparator(comment1, comment2));
   });
 
-  it('sorts by index magnitude as opposed to lexical sorting when sorting by indexes ', function() {
-      var comment1 = new CommentModel({tocId: "TocId", indexes: [0, 3]});
-      var comment2 = new CommentModel({tocId: "TocId", indexes: [0, 20]});
+  it('handles preorder of different lengths when sorting by preorder', function() {
+      var comment1 = new CommentModel({tocId: "toc-preamble-foo", preorder: [0, 3, 2, 1]});
+      var comment2 = new CommentModel({tocId: "toc-preamble-foo", preorder: [0, 3, 3]});
+      assert.equal(-1, commentComparator(comment1, comment2));
+  });
+
+  it('sorts by index magnitude (not lexical) when sorting by preorder ', function() {
+      var comment1 = new CommentModel({tocId: "toc-preamble-foo", preorder: [0, 3]});
+      var comment2 = new CommentModel({tocId: "toc-preamble-foo", preorder: [0, 20]});
       assert.equal(-1, commentComparator(comment1, comment2));
   });
 });

--- a/regulations/static/regulations/js/unittests/specs/collections/comment_collection.js
+++ b/regulations/static/regulations/js/unittests/specs/collections/comment_collection.js
@@ -1,0 +1,37 @@
+var chai = require('chai');
+var assert = chai.assert;
+var jsdom = require('mocha-jsdom');
+
+describe('CommentCollection', function() {
+  jsdom();
+
+  var commentComparator, CommentModel;
+
+  before(function() {
+    Backbone = require('backbone');
+    $ = require('jquery');
+    Backbone.$ = $;
+    var comment_model = require('../../../source/models/comment-model');
+    CommentModel = comment_model.CommentModel;
+    commentComparator = comment_model.commentComparator;
+
+  });
+
+  it('sorts by tocId', function() {
+      var comment1 = new CommentModel({tocId: "TocId 1", indexes: []});
+      var comment2 = new CommentModel({tocId: "TocId 2", indexes: []});
+      assert.equal(-1, commentComparator(comment1, comment2));
+  });
+
+  it('sorts by indexes when tocIds are equal', function() {
+      var comment1 = new CommentModel({tocId: "TocId", indexes: [0, 1]});
+      var comment2 = new CommentModel({tocId: "TocId", indexes: [0, 2]});
+      assert.equal(-1, commentComparator(comment1, comment2));
+  });
+
+  it('sorts by indexes of different lengths when tocIds are equal', function() {
+      var comment1 = new CommentModel({tocId: "TocId", indexes: [0, 3, 2, 1]});
+      var comment2 = new CommentModel({tocId: "TocId", indexes: [0, 3, 3]});
+      assert.equal(-1, commentComparator(comment1, comment2));
+  });
+});

--- a/regulations/static/regulations/js/unittests/specs/views/comment-confirm-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/comment-confirm-view-spec.js
@@ -16,7 +16,7 @@ describe('CommentConfirmView', function() {
     Backbone.$ = $;
     global.localStorage = window.localStorage = storage;
     comments = require('../../../source/collections/comment-collection');
-    CommentModel = require('../../../source/models/comment-model');
+    CommentModel = require('../../../source/models/comment-model').CommentModel;
     CommentConfirmView = require('../../../source/views/comment/comment-confirm-view');
   });
 

--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -9,6 +9,7 @@
     <div
         class="activate-write"
         data-section="{{ node.full_id }}"
+        data-indexes="{{ node.indexes }}"
         data-label="{{ node.human_label }}">
       <a href="#">
         <div class="paragraph-comment-icon">
@@ -44,6 +45,7 @@
     <div
         class="activate-write"
         data-section="{{ node.full_id }}"
+        data-indexes="{{ node.indexes }}"
         data-label="{{ node.human_label }}">
 
       <a href="#">

--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -9,7 +9,7 @@
     <div
         class="activate-write"
         data-section="{{ node.full_id }}"
-        data-indexes="{{ node.indexes }}"
+        data-preorder="{{ node.preorder }}"
         data-label="{{ node.human_label }}">
       <a href="#">
         <div class="paragraph-comment-icon">
@@ -45,7 +45,7 @@
     <div
         class="activate-write"
         data-section="{{ node.full_id }}"
-        data-indexes="{{ node.indexes }}"
+        data-preorder="{{ node.preorder }}"
         data-label="{{ node.human_label }}">
 
       <a href="#">


### PR DESCRIPTION
@cmc333333 , @jmcarp : This PR sorts comments by the keys `tocId` and `indexes`. I would like a critique as I have no experience in writing _idiomatic_ JavaScript. An open issue is that the sort by `tocId` is still lexical and will need to be modified  to reflect:
- Preamble before CFR
- Sorting of parts and sections by the magnitude of the part/section number
For the above issues, I would like to explore if these can be implemented through a server-side (or parse time) ordinal.