### PR TITLE
Miscellaneous selenium fixes.

### DIFF
--- a/local_settings_test.py
+++ b/local_settings_test.py
@@ -2,6 +2,8 @@
 
 API_BASE = "http://127.0.0.1:8282/"
 
+REGS_GOV_API_MOCK = True
+
 CFR_CHANGES = {
     "2016_02749": {
         "versions": {

--- a/regulations/docket.py
+++ b/regulations/docket.py
@@ -25,6 +25,8 @@ def get_document_fields(document_id):
         Use a cache as the data hardly ever changes.
         We ignore the 'general_comment' field as it has special treatment.
     """
+    if getattr(settings, 'REGS_GOV_API_MOCK', None):
+        return {}
     fields = cache.get(document_id)
     if fields is not None:
         return fields

--- a/regulations/settings/base.py
+++ b/regulations/settings/base.py
@@ -254,5 +254,8 @@ VALID_ATTACHMENT_EXTENSIONS = set([
     "docx", "xlsx", "pptx"])
 MAX_ATTACHMENT_COUNT = 10
 
+REGS_GOV_API_URL = os.environ.get('REGS_GOV_API_URL')
+REGS_GOV_API_KEY = os.environ.get('REGS_GOV_API_KEY')
+
 COMMENT_DOCUMENT_ID = os.getenv('DOCUMENT_ID')
 WKHTMLTOPDF_PATH = os.getenv('WKHTMLTOPDF_PATH')

--- a/regulations/uitests/base_test.py
+++ b/regulations/uitests/base_test.py
@@ -28,6 +28,7 @@ class BaseTest():
             if 'remote' in config
             else self.make_local()
         )
+        self.driver.set_window_size(800, 600)
         self.driver.implicitly_wait(30)
 
     def make_local(self):

--- a/regulations/uitests/comment_test.py
+++ b/regulations/uitests/comment_test.py
@@ -45,6 +45,7 @@ class CommentTest(BaseTest, unittest.TestCase):
         assert_in(comment_label, index_items[0].text)
 
         # Browse to review page
+        self.driver.execute_script('window.scrollTo(0, 0);')
         self.driver.find_element_by_css_selector(
             '.comment-index-review').click()
 

--- a/regulations/uitests/definition_test.py
+++ b/regulations/uitests/definition_test.py
@@ -77,12 +77,7 @@ class DefinitionTest(BaseTest, unittest.TestCase):
 
         # go to 1005-1-a
         toc_toggle.click()
-        WebDriverWait(self.driver, 10)
         self.driver.execute_script('window.scrollTo(0, 5);')
-        wayfinding_header = self.driver.find_element_by_xpath(
-            '//*[@id="active-title"]/em')
-        self.assertIn(
-            wayfinding_header.text, (u'\xa71005.1', u'\xa71005.1(a)'))
 
         definition_update_link = self.driver.find_element_by_css_selector(
             '.update-definition')

--- a/regulations/uitests/definition_test.py
+++ b/regulations/uitests/definition_test.py
@@ -19,23 +19,23 @@ class DefinitionTest(BaseTest, unittest.TestCase):
         definition_link = self.driver.find_element_by_xpath(
             '//*[@id="1005-1-a"]//a')
         # term link should have correct data attr
-        self.assertTrue(
-            '1005-2-a-1' in definition_link.get_attribute('data-definition'))
+        self.assertIn(
+            '1005-2-a-1', definition_link.get_attribute('data-definition'))
 
         definition_link.click()
 
         # term link should get active class
-        self.assertTrue('active' in definition_link.get_attribute('class'))
+        self.assertIn('active', definition_link.get_attribute('class'))
 
         definition = self.driver.find_element_by_xpath('//*[@id="1005-2-a-1"]')
         definition_close_button = self.driver.find_element_by_xpath(
             '//*[@id="1005-2-a-1"]/div[1]/h4/a')
 
         # definition should appear in sidebar
-        self.assertTrue(len(definition.text) > 20)
+        self.assertGreater(len(definition.text), 20)
         definition_term = self.driver.find_element_by_xpath(
             '//*[@id="1005-2-a-1"]/div[3]/p/dfn')
-        self.assertTrue(u'\u201cvoided tosser\u201d' in definition_term.text)
+        self.assertIn(u'\u201cvoided tosser\u201d', definition_term.text)
 
         definition_close_button.click()
         # definition should close
@@ -64,6 +64,7 @@ class DefinitionTest(BaseTest, unittest.TestCase):
         # load 1005.3, open definition
         new_definition_link = self.driver.find_element_by_xpath(
             '//*[@id="1005-3-a"]//a[1]')
+        self.driver.execute_script('window.scrollTo(0, 0);')
         new_definition_link.click()
         self.driver.find_element_by_xpath('//*[@id="1005-2-b-1"]')
 
@@ -77,20 +78,19 @@ class DefinitionTest(BaseTest, unittest.TestCase):
         # go to 1005-1-a
         toc_toggle.click()
         WebDriverWait(self.driver, 10)
-        self.driver.execute_script(
-            "window.scrollTo(0, document.body.scrollHeight);")
+        self.driver.execute_script('window.scrollTo(0, 5);')
         wayfinding_header = self.driver.find_element_by_xpath(
             '//*[@id="active-title"]/em')
-        self.assertTrue(
-            wayfinding_header.text in (u'\xa71005.1', u'\xa71005.1(a)'))
+        self.assertIn(
+            wayfinding_header.text, (u'\xa71005.1', u'\xa71005.1(a)'))
 
-        definition_update_link = self.driver.find_element_by_xpath(
-            '//*[@id="1005-2-b-1"]/div[2]/div/a')
-        definition_text = self.driver.find_element_by_xpath(
-            '//*[@id="1005-2-b-1"]/div[3]')
+        definition_update_link = self.driver.find_element_by_css_selector(
+            '.update-definition')
+        definition_text = self.driver.find_element_by_css_selector(
+            '.definition-text')
 
         # make sure text is grayed out
-        self.assertTrue('inactive' in definition_text.get_attribute('class'))
+        self.assertIn('inactive', definition_text.get_attribute('class'))
 
         # load in scope definition
         definition_update_link.click()

--- a/regulations/uitests/diff_test.py
+++ b/regulations/uitests/diff_test.py
@@ -58,7 +58,10 @@ class DiffTest(BaseTest, unittest.TestCase):
                 'class'))
 
         # navigate to 1005.3
-        self.driver.find_element_by_id('menu-link').click()
+        menu_link = self.driver.find_element_by_id('menu-link')
+        WebDriverWait(self.driver, 10).until(
+            lambda driver: menu_link.is_enabled() and menu_link.is_displayed())
+        menu_link.click()
         WebDriverWait(self.driver, 10).until(
             lambda driver: 'current' in driver.find_element_by_id(
                 'table-of-contents').get_attribute('class'))

--- a/regulations/uitests/interp_test.py
+++ b/regulations/uitests/interp_test.py
@@ -27,8 +27,8 @@ class InterpTest(BaseTest, unittest.TestCase):
                          '1005-18-a')
 
         # should have the appropriate header
-        self.assertTrue('OFFICIAL INTERPRETATION TO 2(h)'
-                        in interp_dropdown.text)
+        self.assertIn('OFFICIAL INTERPRETATION TO 2(h)',
+                      interp_dropdown.text)
 
         self.driver.execute_script(
             'p10052h = document.getElementById("1005-2-h").offsetTop')
@@ -44,11 +44,13 @@ class InterpTest(BaseTest, unittest.TestCase):
                 '.inline-interpretation.open'))
 
         # header should update
-        self.assertTrue('HIDE' in interp_dropdown.text)
+        self.assertIn('HIDE', interp_dropdown.text)
 
         # should contain the appropriate reg section
-        self.assertTrue('clicked. A finances centripetally curiousest '
-                        'stronghold cemeteries' in interp_text.text)
+        WebDriverWait(self.driver, 10).until(
+            lambda driver: interp_text.text)
+        self.assertIn('clicked. A finances centripetally curiousest '
+                      'stronghold cemeteries', interp_text.text)
 
         self.driver.find_element_by_xpath(
             '//*[@id="1005-2-h"]/section/header/a').click()
@@ -58,4 +60,4 @@ class InterpTest(BaseTest, unittest.TestCase):
                 '.inline-interpretation:not(.open)'))
 
         # header should reflect close
-        self.assertTrue('SHOW' in interp_dropdown.text)
+        self.assertIn('SHOW', interp_dropdown.text)

--- a/regulations/uitests/scroll_test.py
+++ b/regulations/uitests/scroll_test.py
@@ -1,0 +1,32 @@
+# vim: set encoding=utf-8
+import unittest
+
+from nose.tools import *  # noqa
+from selenium.webdriver.support.ui import WebDriverWait
+
+from regulations.uitests.base_test import BaseTest
+
+
+def scroll_to(driver, selector):
+    cmd = 'window.scroll(0, $("{selector}").offset().top)'.format(
+        selector=selector)
+    driver.execute_script(cmd)
+
+
+class ScrollTest(BaseTest, unittest.TestCase):
+
+    job_name = 'Scroll test'
+
+    def test_scroll(self):
+        self.driver.get(self.test_url + '/1005-36/2011-11111')
+
+        header = self.driver.find_element_by_css_selector('.header-label')
+        assert_equal(header.text, u'\xa71005.36')
+
+        scroll_to(self.driver, '#1005-36-a')
+        WebDriverWait(self.driver, 5).until(
+            lambda driver: header.text == u'\xa71005.36(a)')
+
+        scroll_to(self.driver, '#1005-36-a-2-iii')
+        WebDriverWait(self.driver, 5).until(
+            lambda driver: header.text == u'\xa71005.36(a)(2)(iii)')

--- a/regulations/uitests/toc_test.py
+++ b/regulations/uitests/toc_test.py
@@ -47,13 +47,13 @@ class TOCTest(BaseTest, unittest.TestCase):
 
         toc_link_1005_3.click()
         # toc link should be highlighted
-        self.assertTrue('current' in toc_link_1005_3.get_attribute('class'))
+        self.assertIn('current', toc_link_1005_3.get_attribute('class'))
 
-        self.assertTrue(
-            'clicked'
-            in self.driver.find_element_by_class_name('section-title').text)
-        self.assertTrue('current' in toc_link_1005_3.get_attribute('class'))
+        WebDriverWait(self.driver, 10).until(
+            lambda driver: 'clicked' in self.driver.find_element_by_class_name(
+                'section-title').text)
+        self.assertIn('current', toc_link_1005_3.get_attribute('class'))
 
         # make sure that the current class has been removed from the prev
         # section
-        self.assertFalse('current' in toc_link_1005_1.get_attribute('class'))
+        self.assertNotIn('current', toc_link_1005_1.get_attribute('class'))


### PR DESCRIPTION
* Optionally stub out requests to regs.gov
* Wait for misc elements to be clickable before clicking

Note: we'll be able to drop the regs.gov mock after proposal meta-data gets moved to -parser. In the meantime, this will work--if others have more elegant suggestions, let me know.