### PR TITLE
Two fixes for displaying CFR changes

### DIFF
--- a/regulations/tests/views_preamble_tests.py
+++ b/regulations/tests/views_preamble_tests.py
@@ -215,7 +215,8 @@ class CFRChangeToCTests(TestCase):
     @patch('regulations.views.preamble.utils.regulation_meta')
     def test_add_amendment(self, fetch_meta, fetch_toc):
         """Add amendments for two different CFR parts. Verify that the table
-        of contents contains only the changed data"""
+        of contents contains only the changed data. Also validate that changes
+        to subparts do not include a ToC entry"""
         version_info = {'111': {'left': 'v1', 'right': 'v2'},
                         '222': {'left': 'vold', 'right': 'vnew'}}
         builder = preamble.CFRChangeToC('docdoc', version_info)
@@ -228,6 +229,9 @@ class CFRChangeToCTests(TestCase):
                                        statutory_name='Some title for reg 111')
         builder.add_amendment(dict(cfr_part='111', instruction='1. inst1',
                                    authority='auth1'))
+        # subpart change -- doesn't affect ToC
+        builder.add_amendment(dict(cfr_part='111', instruction='2. inst2',
+                                   changes=[['111-Subpart-A', []]]))
         builder.add_amendment(dict(cfr_part='111', instruction='2. inst2',
                                    # The second element of each pair would be
                                    # non-empty in realistic scenarios

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -158,8 +158,9 @@ class CFRChangeToC(object):
         """While processing an amendment, we will encounter sections we
         haven't seen before -- these will ultimately be ToC entries"""
         change_section = label_parts[1]
-        if (self.current_section is None or
-                self.current_section.section != change_section):
+        is_subpart = 'Subpart' in label_parts or 'Subjgrp' in label_parts
+        if not is_subpart and (self.current_section is None or
+                               self.current_section.section != change_section):
 
             section = '-'.join(label_parts[:2])
             self.current_section = ToCSect(

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -455,12 +455,12 @@ class CFRChangesView(View):
 
         versions = Versions(version_info[cfr_part]['left'],
                             version_info[cfr_part]['right'])
-        tree = ApiReader().regulation(label_id, versions.older)
+        left_tree = ApiReader().regulation(label_id, versions.older)
         appliers = get_appliers(label_id, versions)
 
         builder = CFRChangeHTMLBuilder(
             *appliers, id_prefix=[str(doc_number), 'cfr'])
-        builder.tree = tree
+        builder.tree = left_tree or {}
         builder.generate_html()
 
         return {


### PR DESCRIPTION
1. Don't explode when the change is a whole new section. This is a `None` vs `{}` thing.
2. Don't attempt to display changes to Subparts in the ToC. We'll want to display _something_, but including them in the ToC on par with section changes doesn't make sense and breaks things.