### PR TITLE
Set starting Pre/CFR tab fix

### DIFF
--- a/regulations/static/regulations/js/source/views/drawer/drawer-tabs-view.js
+++ b/regulations/static/regulations/js/source/views/drawer/drawer-tabs-view.js
@@ -45,6 +45,7 @@ var DrawerTabsView = Backbone.View.extend({
     },
 
     setStartingTab: function(tab) {
+        this.$tocLinks.removeClass('current');
         $(this.idMap[tab]).addClass('current');
     },
 

--- a/regulations/static/regulations/js/source/views/drawer/drawer-tabs-view.js
+++ b/regulations/static/regulations/js/source/views/drawer/drawer-tabs-view.js
@@ -45,7 +45,6 @@ var DrawerTabsView = Backbone.View.extend({
     },
 
     setStartingTab: function(tab) {
-        this.$tocLinks.removeClass('current');
         $(this.idMap[tab]).addClass('current');
     },
 

--- a/regulations/templates/regulations/preamble-base.html
+++ b/regulations/templates/regulations/preamble-base.html
@@ -6,7 +6,7 @@
 
 {% block sidebar-icons %}
 <li>
-  <a href="#table-of-contents" id="menu-link" class="toc-nav-link current" title="Preamble Table of Contents">Pre</a>
+  <a href="#table-of-contents" id="menu-link" class="toc-nav-link" title="Preamble Table of Contents">Pre</a>
 </li>
 <li>
   <a href="#table-of-contents-secondary" id="table-of-contents-secondary-link" class="toc-nav-link" title="CFR Changes">CFR</a>


### PR DESCRIPTION
Make sure only the starting tab gets `.current` style to avoid seeing more than one tab "active" at once.

Fixes eregs/notice-and-comment#244

<img width="601" alt="screen shot 2016-05-09 at 1 15 31 pm" src="https://cloud.githubusercontent.com/assets/24054/15121396/810dd25e-15e8-11e6-9a35-1c24b75100ce.png">
