### PR TITLE
Pass empty strings to template for missing values.

### DIFF
--- a/regulations/views/comment.py
+++ b/regulations/views/comment.py
@@ -105,7 +105,7 @@ class SubmitCommentView(View):
         context.update(generate_html_tree(context['preamble'], request,
                                           id_prefix=[doc_number, 'preamble']))
         context['comment_mode'] = 'write'
-        context.update({'message': None, 'metadata_url': None})
+        context.update({'message': '', 'metadata_url': ''})
 
         valid, context['message'] = self.validate(comments, form_data)
         context['regs_gov_url'] = regs_gov_fmt.format(


### PR DESCRIPTION
Django renders `None` as `"None"` unless we use the `default` or
`default_if_none` filters. This leads to an error when comment
submission fails such that the metadata url is empty but appears not to
be, since it shows up as `"None"`. This patch uses empty strings instead
of `None` when template variables are empty.

h/t @donjo 