### PR TITLE
Fix pdf url casing on initial metadata upload.

### DIFF
--- a/regulations/tasks.py
+++ b/regulations/tasks.py
@@ -125,7 +125,7 @@ def cache_pdf(pdf, metadata_url):
     """Update submission metadata and cache comment PDF."""
     url = SignedUrl.generate()
     s3_client.put_object(
-        Body=json.dumps({'pdf_url': metadata_url.url}),
+        Body=json.dumps({'pdfUrl': metadata_url.url}),
         Bucket=settings.ATTACHMENT_BUCKET,
         Key=metadata_url.key,
     )


### PR DESCRIPTION
Currently, pdf urls are stored under "pdf_url" on initial upload and
"pdfUrl" on complete. Given the polling interval, the browser typically
only sees the final metadata payload, but this patch fixes the initial
payload as well.

* Fix pdf url casing
* Add unit tests for `cache_pdf` helper