### PR TITLE
Fix float on pending comment count.

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -362,8 +362,8 @@ a.comment-index-review {
   background-image: url("../img/draft_watermark.png");
 }
 
-.comment-limit,
-.comment-count,
+.comment-attachment-limit,
+.comment-attachment-count,
 .comment-attachments,
 .comment-upload-button {
   float: left;

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -52,8 +52,8 @@ var CommentView = Backbone.View.extend({
     this.$header = this.$el.find('.comment-header');
     this.$container = this.$el.find('.editor-container');
     this.$input = this.$el.find('input[type="file"]');
-    this.$commentCount = this.$el.find('.comment-count');
-    this.$commentLimit = this.$el.find('.comment-limit');
+    this.$attachmentCount = this.$el.find('.comment-attachment-count');
+    this.$attachmentLimit = this.$el.find('.comment-attachment-limit');
     this.$attachments = this.$el.find('.comment-attachments');
     this.$status = this.$el.find('.status');
 
@@ -124,7 +124,7 @@ var CommentView = Backbone.View.extend({
       return new AttachmentView(_.extend({$parent: this.$attachments}, file));
     }.bind(this));
     this.setAttachmentCount();
-    this.$commentLimit.html('<strong>Limit</strong>: ' + MAX_ATTACHMENTS + ' total attachments.');
+    this.$attachmentLimit.html('<strong>Limit</strong>: ' + MAX_ATTACHMENTS + ' total attachments.');
   },
 
   highlightDropzone: function() {
@@ -197,7 +197,7 @@ var CommentView = Backbone.View.extend({
     count += this.attachmentViews.length;
     this.attachmentCount = count;
     var plural = this.attachmentCount !== 1 ? 's' : '';
-    this.$commentCount.text('You\'ve uploaded ' + this.attachmentCount + ' total attachment' + plural + '.');
+    this.$attachmentCount.text('You\'ve uploaded ' + this.attachmentCount + ' total attachment' + plural + '.');
     this.$input.prop('disabled', this.attachmentCount >= MAX_ATTACHMENTS);
   },
 

--- a/regulations/static/regulations/js/unittests/specs/views/comment-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/comment-view-spec.js
@@ -32,8 +32,8 @@ describe('CommentView', function() {
           '<div class="comment-attachments"></div>' +
           '<input type="file">' +
           '<button type="submit">Save</button>' +
-          '<div class="comment-count"></div>' +
-          '<div class="comment-limit"></div>' +
+          '<div class="comment-attachment-count"></div>' +
+          '<div class="comment-attachment-limit"></div>' +
           '<div class="comment-clear">Clear</div>' +
           '<div class="status"></div>' +
         '</form>' +
@@ -99,7 +99,7 @@ describe('CommentView', function() {
     commentView.setSection('2016_02479');
     commentView.setAttachmentCount();
     expect(commentView.$input.prop('disabled')).to.be.false;
-    expect(commentView.$commentCount.text()).to.include('0 total attachments');
+    expect(commentView.$attachmentCount.text()).to.include('0 total attachments');
   });
 
   it('ignores comments for with different doc ids', function() {
@@ -116,7 +116,7 @@ describe('CommentView', function() {
     });
     commentView.setAttachmentCount();
     expect(commentView.$input.prop('disabled')).to.be.false;
-    expect(commentView.$commentCount.text()).to.include('3 total attachments');
+    expect(commentView.$attachmentCount.text()).to.include('3 total attachments');
   });
 
   it('forbids attachments when at max', function() {
@@ -133,6 +133,6 @@ describe('CommentView', function() {
     });
     commentView.setAttachmentCount();
     expect(commentView.$input.prop('disabled')).to.be.true;
-    expect(commentView.$commentCount.text()).to.include('9 total attachments');
+    expect(commentView.$attachmentCount.text()).to.include('9 total attachments');
   });
 });

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -33,8 +33,8 @@
               <button class="comment-upload-button file-upload">
                 Upload Attachment<input type="file" multiple/>
               </button>
-              <div class="comment-count"></div>
-              <div class="comment-limit"></div>
+              <div class="comment-attachment-count"></div>
+              <div class="comment-attachment-limit"></div>
             </div>
             <div class="comment-submission">
               <button class="comment-button" type="submit">Save Response</button>


### PR DESCRIPTION
Before:

<img width="262" alt="screen shot 2016-05-10 at 12 25 15 pm" src="https://cloud.githubusercontent.com/assets/1633460/15154175/534d3806-16aa-11e6-92d3-e3de577a5d60.png">

After:

<img width="259" alt="screen shot 2016-05-10 at 12 25 23 pm" src="https://cloud.githubusercontent.com/assets/1633460/15154186/5aecc18a-16aa-11e6-8771-d31b75b46f86.png">

The issue comes from using one class to do two different things, so that we float the pending comment count left when we shouldn't. This patch uses distinct and hopefully clearer class names here. Separately, since the only purpose of the `"comment-count"` class is to bold the pending comment count, we could drop that class and just use `<strong>` instead.