### PR TITLE
[WIP] Hide comment markup when comment period is closed.

### DIFF
--- a/regulations/static/regulations/js/source/views/main/preamble-view.js
+++ b/regulations/static/regulations/js/source/views/main/preamble-view.js
@@ -88,12 +88,15 @@ var PreambleView = ChildView.extend({
     $parent = $parent.clone();
     $parent.find('.activate-write').remove();
 
-    CommentEvents.trigger('comment:target', {
-      section: section,
-      tocId: tocId,
-      label: label,
-      $parent: $parent
-    });
+    if (section) {
+      CommentEvents.trigger('comment:target', {
+        section: section,
+        tocId: tocId,
+        label: label,
+        $parent: $parent
+      });
+    }
+
     this.$read.hide();
     this.$write.show();
   },

--- a/regulations/templates/regulations/comment-write-closed.html
+++ b/regulations/templates/regulations/comment-write-closed.html
@@ -1,0 +1,19 @@
+<div>
+  <h1>Comment period closed</h1>
+  {% if meta.comments_close %}
+    <div>
+      As of <strong>{{meta.comments_close|date:"F j, Y"}} at 11:59pm EST</strong>, we are no longer accepting comments on this rule.
+    </div>
+  {% endif %}
+  <div>
+    <a href="#">Visit the docket ({{meta.dockets|join:"; "}})</a> to view all the public comments on this rule:
+    <div>
+      {% for title_info in meta.cfr_parts %}
+        {{title_info.title}} CFR Parts {{title_info.parts|join:", "}}<br />
+      {% endfor %}
+    </div>
+  </div>
+  <div>
+    <a href="{{request.path}}">Back to read the proposal</a>
+  </div>
+</div>

--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -5,7 +5,7 @@
 {% if node.header %}
 <div class="node">
   <h{{ node.list_level|add:"+3" }} class="section-header">{{ node.header | safe }}</h{{ node.list_level|add:"+3" }}>
-  {% if node.accepts_comments %}
+  {% if meta.accepts_comments and node.accepts_comments %}
     <div
         class="activate-write"
         data-section="{{ node.full_id }}"
@@ -40,7 +40,7 @@
 
     </p>
 
-    {% if node.accepts_comments and not node.title %}
+    {% if meta.accepts_comments and node.accepts_comments and not node.title %}
     <div
         class="activate-write"
         data-section="{{ node.full_id }}"

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -22,30 +22,34 @@
 
     <div id="preamble-write">
       <div class="comment-wrapper">
-        <div class="comment">
-          <h2>Write your comment.</h2>
-          <h3 class="comment-header"></h3>
-          <div class="comment-context"></div>
-          <form>
-            <div class="editor-container"></div>
-            <div class="comment-controls">
-              <div class="comment-attachments"></div>
-              <button class="comment-upload-button file-upload">
-                Upload Attachment<input type="file" multiple/>
-              </button>
-              <div class="comment-attachment-count"></div>
-              <div class="comment-attachment-limit"></div>
-            </div>
-            <div class="comment-submission">
-              <button class="comment-button" type="submit">Save Response</button>
-              <div class="status"></div>
-            </div>
-          </form>
+        {% if meta.accepts_comments %}
+          <div class="comment">
+            <h2>Write your comment.</h2>
+            <h3 class="comment-header"></h3>
+            <div class="comment-context"></div>
+            <form>
+              <div class="editor-container"></div>
+              <div class="comment-controls">
+                <div class="comment-attachments"></div>
+                <button class="comment-upload-button file-upload">
+                  Upload Attachment<input type="file" multiple/>
+                </button>
+                <div class="comment-attachment-count"></div>
+                <div class="comment-attachment-limit"></div>
+              </div>
+              <div class="comment-submission">
+                <button class="comment-button" type="submit">Save Response</button>
+                <div class="status"></div>
+              </div>
+            </form>
+          </div>
         </div>
-      </div>
-      <div class="comment-index">
-        <ul class="comment-index-items"></ul>
-        <a href="{% url 'comment_review' doc_number=doc_number %}" class="comment-index-review">Review and Submit</a>
+        <div class="comment-index">
+          <ul class="comment-index-items"></ul>
+          <a href="{% url 'comment_review' doc_number=doc_number %}" class="comment-index-review">Review and Submit</a>
+        {% else %}
+          {% include "regulations/comment-write-closed.html" %}
+        {% endif %}
       </div>
     </div>
   </section>

--- a/regulations/templates/regulations/tree/preamble_intro.html
+++ b/regulations/templates/regulations/tree/preamble_intro.html
@@ -8,7 +8,7 @@
     id="{{node.markup_id}}"
     data-permalink-section>
   <div class="node">
-    {% if node.accepts_comments %}
+    {% if meta.accepts_comments and node.accepts_comments %}
       <div
           class="activate-write"
           data-section="{{ node.full_id }}"
@@ -24,8 +24,10 @@
     <h4>{{ meta.primary_agency }}</h4>
     <h3>{{ meta.title }}</h3>
     <div>
-      <div>{{ meta.days_remaining }} Days</div>
-      <h5>Comment period closes on {{ meta.comments_close|date:"F j, Y" }} at 11:59pm
+      {% if meta.accepts_comments %}
+        <div>{{ meta.days_remaining }} Days</div>
+      {% endif %}
+    <h5>Comment period {% if meta.accepts_comments %}closes{% else %}closed{% endif %} on {{ meta.comments_close|date:"F j, Y" }} at 11:59pm
         EST.</h5>
       Rule published {{ meta.publication|date:"F j, Y"}}
     </div>

--- a/regulations/views/comment.py
+++ b/regulations/views/comment.py
@@ -102,6 +102,11 @@ class SubmitCommentView(View):
         comments = json.loads(request.POST.get('comments', '[]'))
 
         context = common_context(doc_number)
+
+        if not context['meta']['accepts_comments']:
+            raise Http404(
+                "Comment period for doc # {} closed".format(doc_number))
+
         context.update(generate_html_tree(context['preamble'], request,
                                           id_prefix=[doc_number, 'preamble']))
         context['comment_mode'] = 'write'


### PR DESCRIPTION
Not finished, but wanted to submit the wip to get opinions on a few (minor) issues:

* Prefer a new template variable (here, `accepts_comments`), or stick with `days_remaining`? The latter would mean including logic like `{% if days_remaining >= 0}` in the templates, which is why I'm avoiding it for now
* Prefer 404 or redirect when a user tries to open a page that's not available (comment review or submit when comment period is closed)?
* I just took a guess at what the preamble intro should say when comments are closed.

Also, we'll need an override in n&c for the write mode text on comment period closed (as this is implemented now, at least).

cc @cmc333333 