### PR TITLE
Add display of subpart additions/wayfinding

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -63,9 +63,6 @@ comment.less contains styles related to commenting on sections
       &.current {
         background-color: @pacific;
       }
-      span {
-        display: none;
-      }
     }
   }
 

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -40,12 +40,33 @@ comment.less contains styles related to commenting on sections
     }
   }
 
-  li > .show-more-context {
+  li > .show-more-context,
+  .section-title,
+  .subpart-addition,
+  .subpart-info {
     width: 75%;
   }
 
-  .section-title {
-    width: 75%;
+  .subpart-info {
+    border-bottom: 1px solid @grey;
+
+    .subpart-wayfinding {
+      display: inline-block;
+      float: right;
+    }
+    a {
+      display: inline-block;
+      height: 20px;
+      width: 20px;
+      background-color: @grey;
+
+      &.current {
+        background-color: @pacific;
+      }
+      span {
+        display: none;
+      }
+    }
   }
 
   .cfr-instructions {

--- a/regulations/templates/regulations/cfr_changes.html
+++ b/regulations/templates/regulations/cfr_changes.html
@@ -10,6 +10,25 @@
   </div>
 {% endfor %}
 
+{% for subpart in subparts %}
+<h3 class="subpart-addition">
+  <ins>Subpart {{subpart.letter}} &mdash; {{subpart.title}}</ins>
+</h3>
+<div class="subpart-info">
+  <div class="subpart-wayfinding">
+    {% for url in subpart.urls %}
+      <a href="{{url}}"
+         {% if forloop.counter0 == subpart.idx %}class="current"{% endif %}
+       ><span>{{forloop.counter}}/{{subpart.urls|length}}</span></a>
+    {% endfor %}
+  </div>
+  <p>This is section
+    <strong>{{subpart.idx|add:"1"}} of {{subpart.urls|length}}</strong>
+    in subpart {{subpart.letter}}
+  </p>
+</div>
+{% endfor %}
+
 {% if tree %}
   {% with c=tree %}
   {% include "regulations/regulation_text.html" %}

--- a/regulations/templates/regulations/cfr_changes.html
+++ b/regulations/templates/regulations/cfr_changes.html
@@ -18,8 +18,9 @@
   <div class="subpart-wayfinding">
     {% for url in subpart.urls %}
       <a href="{{url}}"
+         aria-label="{{forloop.counter}} of {{subpart.urls|length}} sections"
          {% if forloop.counter0 == subpart.idx %}class="current"{% endif %}
-       ><span>{{forloop.counter}}/{{subpart.urls|length}}</span></a>
+       >&nbsp;</a>
     {% endfor %}
   </div>
   <p>This is section

--- a/regulations/tests/views_preamble_tests.py
+++ b/regulations/tests/views_preamble_tests.py
@@ -188,7 +188,7 @@ class CFRChangesViewTests(TestCase):
     def test_new_regtext_changes(self, get_appliers, ApiReader):
         """We can add a whole new section without explosions"""
         amendments = [{'instruction': '3. Add section 44',
-                       'changes': {'111-44': {'some': 'thing'}}},
+                       'changes': [['111-44', {'some': 'thing'}]]},
                       {'instruction': '4. Unrelated'}]
         version_info = {'111': {'left': '234-567', 'right': '8675-309'}}
 

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -452,8 +452,6 @@ class CFRChangesView(View):
         relevant = []
         for amd in amendments:
             changes = amd.get('changes', [])
-            if isinstance(changes, dict):
-                changes = list(changes.items())
             keys = {change[0] for change in changes}
             if any(is_contained_in(key, label_id) for key in keys):
                 relevant.append(amd)


### PR DESCRIPTION
Looks like
<img width="706" alt="screen shot 2016-05-10 at 5 06 15 pm" src="https://cloud.githubusercontent.com/assets/326918/15162583/aef27c9e-16d1-11e6-91c9-8b74c403daa2.png">

Should resolve eregs/notice-and-comment#119 and eregs/notice-and-comment#198