### PR TITLE
Comment Review Disclaimers

### DIFF
--- a/regulations/static/regulations/css/less/base-variables.less
+++ b/regulations/static/regulations/css/less/base-variables.less
@@ -12,7 +12,7 @@ variables.less contains all theme variable / variable overrides
 @green_midtone: #ADDC91;
 @green_light: #DBEDD4;
 @black: #101820;
-@white: #ffffff;
+@white: #FFFFFF;
 @dark_field: #5C6065;
 @light_field: #D1D3D5;
 @grey: #E6E7E9;

--- a/regulations/static/regulations/css/less/base-variables.less
+++ b/regulations/static/regulations/css/less/base-variables.less
@@ -12,6 +12,7 @@ variables.less contains all theme variable / variable overrides
 @green_midtone: #ADDC91;
 @green_light: #DBEDD4;
 @black: #101820;
+@white: #ffffff;
 @dark_field: #5C6065;
 @light_field: #D1D3D5;
 @grey: #E6E7E9;

--- a/regulations/static/regulations/css/less/base-variables.less
+++ b/regulations/static/regulations/css/less/base-variables.less
@@ -18,6 +18,7 @@ variables.less contains all theme variable / variable overrides
 @grey: #E6E7E9;
 @red_orange: #D12124;
 @pacific: #0072CE;
+@blue: #0072CE;
 @link_blue: #348dc9; /* blue used for link borders and search results */
 @light_neutral: #D7D2CB;
 @dark_gray: #797D81

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -532,8 +532,8 @@ a.comment-index-review {
   }
 
   .additional-info {
-    padding: 0 0 10px 0;
     max-width: 535px;
+    border-bottom: 2px solid @light_field;
 
     h4 {
       margin-bottom: 0.75em;
@@ -567,13 +567,45 @@ a.comment-index-review {
   }
 
   .statement {
-    border-top: 1px solid @text_area_border;
     padding: 10px 0 0;
-    margin: 15px 0 25px 0;
-    max-width: 535px;
+    margin: 5px 0 30px 0;
+    max-width: 620px;
 
     .required {
       color: @red_orange;
+    }
+
+    .statement-list li {
+      margin-top: 0.5em;
+      list-style-type: disc;
+    }
+
+    p {
+      font-size: 12px;
+      line-height: 18px;
+      margin: 0.5em 0;
+    }
+
+    h6 {
+      .font-regular;
+      font-size: 16px;
+      text-transform: none;
+      display: inline;
+    }
+
+    .show-more-toggle {
+      display: inline;
+      color: @blue;
+      font-size: 14px;
+
+      &:hover {
+        color: darken(@blue, 10%);
+      }
+
+      .text-expand {
+        font-size: 13px;
+        padding: 0 3px;
+      }
     }
   }
 

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -505,9 +505,10 @@ a.comment-index-review {
 
     h4 {
       color: @pacific;
+      margin: 0;
       float: left;
       font-size: 18px;
-      line-height: 18px;
+      line-height: 22px;
       text-transform: inherit;
       max-width: 425px;
 
@@ -533,7 +534,64 @@ a.comment-index-review {
 
   .additional-info {
     max-width: 535px;
+    padding-bottom: 30px;
     border-bottom: 2px solid @light_field;
+
+    .tabs {
+      margin: 10px 0;
+    }
+
+    .btn-group {
+      display: inline-block;
+      list-style: none;
+    }
+
+    .btn-group-item {
+      display: inline-block;
+      background: @grey;
+      font-size: 14px;
+      line-height: 18px;
+      padding: 8px 15px;
+      box-shadow: inset 0 0 1px fade(@dark_gray, 90%);
+      border-radius: 2px;
+      cursor: pointer;
+
+      &:hover {
+        background: darken(@grey, 10%);
+      }
+      &:active {
+        background: darken(@grey, 20%);
+      }
+    }
+
+    .comment-form-subtext {
+      display: block;
+      font-size: 14px;
+      line-height: 14px;
+    }
+
+    .comment-form-fieldlabel {
+      font-size: 16px;
+      .font-bold;
+    }
+
+    .labeled-field {
+      margin: 5px 0;
+    }
+
+    select {
+      width: 100%;
+      background: @white;
+      font-size: 14px;
+      line-height: 18px;
+      padding: 12px 10px;
+      margin: 5px 0;
+      height: auto;
+      border-radius: 3px;
+      border: 1px solid rgba(0,0,0,.25);
+      box-shadow: inset 0 0 1px fade(@dark_gray, 90%);
+      color: @black;
+    }
 
     h4 {
       margin-bottom: 0.75em;
@@ -573,6 +631,7 @@ a.comment-index-review {
 
     .required {
       color: @red_orange;
+      margin-left: 5px;
     }
 
     .statement-list li {

--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -117,10 +117,10 @@ var CommentReviewView = Backbone.View.extend({
       var $target = $('#' + $elm.data('toggle'));
       if ($target.is(':visible')) {
         $target.hide();
-        $elm.text($target.data('more-text') || 'Show more');
+        $elm.html($target.data('more-text') || '<span class="fa fa-plus-circle text-expand" aria-hidden="true"></span>Show more');
       } else {
         $target.show();
-        $elm.text($target.data('less-text') || 'Show less');
+        $elm.html($target.data('less-text') || '<span class="fa fa-minus-circle text-expand" aria-hidden="true"></span>Show less');
       }
     }
     var $toggles = this.$el.find('[data-toggle]');


### PR DESCRIPTION
fixes eregs/notice-and-comment#246


![screen shot 2016-05-11 at 11 32 22 am](https://cloud.githubusercontent.com/assets/776987/15188864/80e0387c-176d-11e6-9a61-32e80cea1c60.png)


These are the styles to go with eregs/notice-and-comment#270 so you'll probably need to pull both down at the same time. 

There are a some pieces of functionality/bugs that still need to be addressed:
- Myself/Org/Gov buttons are "active" based on the selection of form fields a user is looking at.
- Government Agency field is always displaying, should only display on the final option of the three.
- Government Agency field should be a dropdown when there are options available to be dropped down, otherwise an open text field.

Once those are addressed I can swing back and look at the two style issues that will needed to be looked at: 
- CSS for an "active" state on myself/org/gov buttons
- Dropdown arrow added to dropdowns.
