### PR TITLE
Tweak ProseMirror menu

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -596,6 +596,17 @@ a.comment-index-review {
   }
 }
 
+.comment-content,
+.ProseMirror-content {
+  li {
+    list-style-type: inherit;
+  }
+  ol {
+    list-style-type: decimal;
+  }
+}
+
+
 // margins in .preamble-wrapper are overrides for things defined in .main-content
 // because the preamble doesn't use the right sidebar
 

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -68,7 +68,7 @@ var CommentView = Backbone.View.extend({
         'code:toggle': {menu: null},
         'code_block:make': {menu: null},
         'image:insert': {menu: null},
-        selectParentNode: {menu: null}
+        'selectParentNode': {menu: null}
       }),
       place: this.$container.get(0),
       docFormat: 'markdown',

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -7,7 +7,8 @@ var filesize = require('filesize');
 Backbone.$ = $;
 
 var edit = require('prosemirror/dist/edit');
-require('prosemirror/dist/menu/tooltipmenu');
+var menu = require('prosemirror/dist/menu/menu');
+require('prosemirror/dist/menu/menubar');
 require('prosemirror/dist/markdown');
 
 var MainEvents = require('../../events/main-events');
@@ -57,8 +58,18 @@ var CommentView = Backbone.View.extend({
     this.$attachments = this.$el.find('.comment-attachments');
     this.$status = this.$el.find('.status');
 
+    var hrGroup = new menu.MenuCommandGroup('insert');
+    var headingMenu = new menu.Dropdown({
+      label: 'Heading', displayActive: true
+    }, [new menu.MenuCommandGroup('textblock'), new menu.MenuCommandGroup('textblockHeading')]);
     this.editor = new edit.ProseMirror({
-      tooltipMenu: true,
+      menuBar: {content: [menu.inlineGroup, headingMenu, menu.blockGroup, hrGroup]},
+      commands: edit.CommandSet.default.update({
+        'code:toggle': {menu: null},
+        'code_block:make': {menu: null},
+        'image:insert': {menu: null},
+        selectParentNode: {menu: null}
+      }),
       place: this.$container.get(0),
       docFormat: 'markdown',
       doc: ''

--- a/regulations/static/regulations/js/unittests/specs/views/comment-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/comment-view-spec.js
@@ -50,6 +50,7 @@ describe('CommentView', function() {
       .append($template);
     sinon.stub(edit.ProseMirror.prototype, 'getContent');
     sinon.stub(edit.ProseMirror.prototype, 'setContent');
+    sinon.stub(edit.ProseMirror.prototype, 'ensureOperation');
     commentView = new CommentView({el: $el, docId: '2016_02749'});
     comments.reset();
   });
@@ -57,6 +58,7 @@ describe('CommentView', function() {
   afterEach(function() {
     edit.ProseMirror.prototype.getContent.restore();
     edit.ProseMirror.prototype.setContent.restore();
+    edit.ProseMirror.prototype.ensureOperation.restore();
   });
 
   it('removes an attachment', function() {

--- a/regulations/templates/regulations/comment.html
+++ b/regulations/templates/regulations/comment.html
@@ -9,7 +9,9 @@
 
   {% for section in sections %}
     <h1>{{section.label}}</h1>
-    {{section.commentHtml|safe}}
+    <div class="comment-content">
+      {{section.commentHtml|safe}}
+    </div>
     {% if section.files %}
       <h2>Attachments</h2>
       <ul>


### PR DESCRIPTION
Makes ProseMirror's menu hang out at the top of the text box rather than be
inline. This also adds a change to the pdf template (so that it uses the same
class for comment content) and to CSS styles around li/ols (which are
list-style-type: none elsewhere in the app).

Looks like
<img width="673" alt="screen shot 2016-05-11 at 1 33 58 pm" src="https://cloud.githubusercontent.com/assets/326918/15190430/d63041cc-177d-11e6-8cde-e0b5b032a86a.png">

Resolves eregs/notice-and-comment#200