### PR TITLE
Use real data for CFR changes, when available

### DIFF
--- a/regulations/tests/views_preamble_tests.py
+++ b/regulations/tests/views_preamble_tests.py
@@ -96,21 +96,21 @@ class PreambleViewTests(TestCase):
     )
     @patch('regulations.views.preamble.ApiReader')
     def test_comments_open(self, ApiReader):
-        _, intro = preamble.get_preamble('1')
-        assert_true(intro['meta']['accepts_comments'])
+        _, meta, _ = preamble.notice_data('1')
+        assert_true(meta['accepts_comments'])
 
     @override_settings(
         PREAMBLE_INTRO=make_intro('1', date.today() - timedelta(days=1)),
     )
     @patch('regulations.views.preamble.ApiReader')
     def test_comments_closed(self, ApiReader):
-        _, intro = preamble.get_preamble('1')
-        assert_false(intro['meta']['accepts_comments'])
+        _, meta, _ = preamble.notice_data('1')
+        assert_false(meta['accepts_comments'])
 
     @patch('regulations.views.preamble.ApiReader')
     def test_comments_final(self, ApiReader):
-        _, intro = preamble.get_preamble('1')
-        assert_false(intro['meta']['accepts_comments'])
+        _, meta, _ = preamble.notice_data('1')
+        assert_false(meta['accepts_comments'])
 
     @patch('regulations.views.preamble.CFRChangeToC')
     @patch('regulations.generator.generator.api_reader')
@@ -155,7 +155,7 @@ class PreambleViewTests(TestCase):
         for doc_id in ('123_456', '123-456'):
             preamble_, meta, notice = preamble.notice_data(doc_id)
             self.assertEqual(preamble_, self._mock_preamble)
-            self.assertEqual({}, meta)
+            self.assertEqual({'accepts_comments': False}, meta)
             self.assertEqual({'some': 'notice'}, notice)
             self.assertEqual(ApiReader.return_value.preamble.call_args[0][0],
                              '123_456')

--- a/regulations/tests/views_preamble_tests.py
+++ b/regulations/tests/views_preamble_tests.py
@@ -113,6 +113,23 @@ class PreambleViewTests(TestCase):
                           RequestFactory().get('/preamble/1/not/here'),
                           paragraphs='1/not/here')
 
+    @patch('regulations.views.preamble.ApiReader')
+    def test_notice_data(self, ApiReader):
+        """We should try to fetch data corresponding to both the Preamble and
+        the Notice"""
+        ApiReader.return_value.preamble.return_value = self._mock_preamble
+        ApiReader.return_value.notice.return_value = {'some': 'notice'}
+
+        for doc_id in ('123_456', '123-456'):
+            preamble_, meta, notice = preamble.notice_data(doc_id)
+            self.assertEqual(preamble_, self._mock_preamble)
+            self.assertEqual({}, meta)
+            self.assertEqual({'some': 'notice'}, notice)
+            self.assertEqual(ApiReader.return_value.preamble.call_args[0][0],
+                             '123_456')
+            self.assertEqual(ApiReader.return_value.notice.call_args[0][0],
+                             '123-456')
+
 
 class PreambleToCTests(TestCase):
 

--- a/regulations/views/comment.py
+++ b/regulations/views/comment.py
@@ -18,8 +18,7 @@ from django.views.generic.base import View
 from regulations import tasks
 from regulations import docket
 from regulations.views.preamble import (
-    common_context, generate_html_tree, get_preamble,
-    first_preamble_section)
+    common_context, generate_html_tree, first_preamble_section, notice_data)
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +86,7 @@ regs_gov_fmt = 'https://www.regulations.gov/#!documentDetail;D={document}'
 class SubmitCommentView(View):
 
     def get(self, request, doc_number):
-        preamble, _ = get_preamble(doc_number)
+        preamble, _, _ = notice_data(doc_number)
         section = first_preamble_section(preamble)
         if section is None:
             raise Http404

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -118,8 +118,6 @@ def merge_cfr_changes(doc_number, notice):
     amendments = list(mock_notice.get('amendments', []))    # copy
     amendments.extend(notice.get('amendments', []))
 
-    print len(amendments)
-
     return versions, amendments
 
 


### PR DESCRIPTION
Attempt to fetch the relevant notice when generating the CFR changes (for both
the table of contents and to display their amendments). To be backwards
compatible, allow the data to continue to be derived from the mock data
source.

With this, we'll be able to view (and verify) diffs for the upcoming proposal.

I'd like to refactor this further, but I don't want to step on @tadhg-ohiggins 's toes as he works on the meta data parts.

Note that this changes the logic so that we don't 404 on "missing" CFR changes. It's very possible that a notice will have no CFR changes.