### PR TITLE
Layout styles for write mode tab

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -208,8 +208,16 @@ Write Mode
       .ProseMirror-content {
         height: 200px;
         resize: vertical;
+        outline: none;
         overflow-y: auto;
         padding: 12px 15px;
+      }
+
+      .ProseMirror-menubar {
+        min-height: 28px;
+        padding: 3px 6px;
+        color: @dark_field;
+        border-bottom: 1px solid @light_field;
       }
 
       .comment-content,
@@ -302,8 +310,12 @@ Write Mode
 
   .comment-context {
     margin: 0 0 25px 0;
-    max-height: 250px;
+    padding: 0 20px;
+    max-height: 400px;
     overflow: auto;
+    border: 1px solid transparent;
+    box-shadow: 0 0 1px 1px @text_area_border;
+    border-radius: 2px
   }
 
 }
@@ -312,11 +324,15 @@ Write Mode
   .font-regular;
   position: absolute;
   right: -290px;
-  top: 15px;
+  top: -15px;
   width: 250px;
 
   .comment-index-items {
     margin: 0 0 15px 0;
+
+    & > h3 {
+      margin: 0.6em 0 0 0;
+    }
 
     p {
       .font-regular;
@@ -396,6 +412,10 @@ Write Mode
   clear: both;
 }
 
+.comment-attachment-count {
+  margin-top: 10px;
+}
+
 .comment-attachments {
   display: inline-block;
   margin-bottom: 5px;
@@ -423,5 +443,14 @@ Write Mode
       color: @black;
       cursor: pointer;
     }
+  }
+}
+
+.comment-header {
+  margin: 0.6em 0;
+
+  & > a {
+    color: @black;
+    border-bottom: 2px solid fade(@blue, 80%);
   }
 }

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -104,12 +104,12 @@ var CommentView = Backbone.View.extend({
       var href = window.APP_PREFIX + parsed.path.join('/') + '#' + parsed.hash;
       // Splice section label and context title, if present
       // TODO: Build this upstream
-      var $sectionHeader = options.$parent.find('.node:first :header, .section-title:header');
+      var $sectionHeader = options.$parent.find('.node:first :header');
       if ($sectionHeader.length) {
         label = [label, $sectionHeader.text().split('. ').slice(1)].join('. ');
         $sectionHeader.remove();
       }
-      this.$header.html('<a href="' + href + '">' + label + '</a>');
+      this.$header.append('<a href="' + href + '">' + label + '</a>');
       this.$context.append(options.$parent);
     }
   },

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -24,9 +24,9 @@
       <div class="comment-wrapper">
         {% if meta.accepts_comments %}
           <div class="comment">
-            <h2>Write your comment.</h2>
-            <h3 class="comment-header"></h3>
+            <h3 class="comment-header">You are writing a comment about </h3>
             <div class="comment-context"></div>
+            <h3 class="comment-header">Write your response to </h3>
             <form>
               <div class="editor-container"></div>
               <div class="comment-controls">


### PR DESCRIPTION
![screen shot 2016-05-12 at 12 16 14 pm](https://cloud.githubusercontent.com/assets/776987/15229240/baf9dbce-1855-11e6-8f4e-a44667c8014e.png)

These are just the changes to the layout and presentation of the write mode page as described in eregs/notice-and-comment#202.

The comment-context box still needs styling and show more/show less functionality.
