### PR TITLE
Use docker for integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
-sudo: false
+dist: trusty      # per https://github.com/travis-ci/travis-ci/issues/5448
+sudo: required    # required for docker
 cache:
   directories:
     - $HOME/.cache/pip
@@ -10,7 +11,7 @@ matrix:
     - python: '3.3'
     - python: '3.4'
     - python: '3.5'
-    - python: '2.7'
+    - python: '3.5'
       addons:
         sauce_connect: true
       env:

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -2,7 +2,9 @@
 
 set -ev
 
-./dummy_api/start.sh
+cd dummy_api
+./start.sh
+cd ..
 cp local_settings_test.py local_settings.py
 ./run_server.sh &
 sleep 5


### PR DESCRIPTION
We had been checking out the full parser and api source (one of which required
Python 2.7), and installing additional requirements. This uses docker instead
with the latest images. Ideally we'll remove the dummy data altogether and run
a real regulation soon.

Depends on eregs/regulations-core#52