### PR TITLE
Add links to supporting documents

### DIFF
--- a/regulations/templates/regulations/tree/preamble_intro.html
+++ b/regulations/templates/regulations/tree/preamble_intro.html
@@ -31,7 +31,11 @@
         EST.</h5>
       Rule published {{ meta.publication|date:"F j, Y"}}
     </div>
-    {% comment %}Jump links will go here{% endcomment %}
+    {% if meta.supporting_documents %}
+    <div>
+      <a href="#supporting-docs">View supporting documents from the docket</a>
+    </div>
+    {% endif %}
     <hr />
     <p>
       {% for title_info in meta.cfr_parts %}
@@ -47,3 +51,14 @@
     {% include node.template_name %}
   {% endwith %}
 {% endfor %}
+{% if meta.supporting_documents %}
+  <li>
+    <h4 id="supporting-docs">Supporting documents from the docket:</h4>
+    <ol>
+      {% for doc in meta.supporting_documents|slice:":3" %}
+        <li><a href="https://www.regulations.gov/#!documentDetail;D={{doc.regs_id}}">{{doc.title}}</a></li>
+      {% endfor %}
+      <li><a href="https://www.regulations.gov/#!docketBrowser;rpp=25;po=0;dct=SR%252BO;D={{meta.primary_docket}}">View all</a></li>
+    </ol>
+  </li>
+{% endif %}

--- a/regulations/templates/regulations/tree/preamble_intro.html
+++ b/regulations/templates/regulations/tree/preamble_intro.html
@@ -32,7 +32,7 @@
       Rule published {{ meta.publication|date:"F j, Y"}}
     </div>
     {% if meta.supporting_documents %}
-    <div>
+    <div class="view-supporting-docs">
       <a href="#supporting-docs">View supporting documents from the docket</a>
     </div>
     {% endif %}


### PR DESCRIPTION
Not styled appropriately, but this adds appropriate links for supporting
documents in the regs.gov docket

For eregs/notice-and-comment#295. To see this in action, apply the following diff:
```diff
diff --git a/notice_and_comment/settings/base.py b/notice_and_comment/settings/base.py
index bb0c858..efd8332 100644
--- a/notice_and_comment/settings/base.py
+++ b/notice_and_comment/settings/base.py
@@ -107,6 +107,14 @@ CFR_CHANGES = {
 PREAMBLE_INTRO = {
     "0000_0000": {
         "meta": {
+            "supporting_documents": [
+                {"regs_id": "AAAAA", "title": "A document title"},
+                {"regs_id": "BBBBB", "title": "B document title"},
+                {"regs_id": "CCCCC", "title": "C document title"},
+                {"regs_id": "DDDDD", "title": "D document title"},
+                {"regs_id": "EEEEE", "title": "E document title"},
+            ],
+            "primary_docket": "DOCKETDOCKET",
             "primary_agency": "Environmental Protection Agency",
             "title": "EPA's new proposal",
             "comments_close": "2016-05-29",
```

Looks like:
<img width="636" alt="screen shot 2016-05-17 at 5 15 22 pm" src="https://cloud.githubusercontent.com/assets/326918/15339554/fd241784-1c52-11e6-862a-a1d188c57552.png">
...
<img width="716" alt="screen shot 2016-05-17 at 5 15 31 pm" src="https://cloud.githubusercontent.com/assets/326918/15339555/004136b8-1c53-11e6-8bb8-2bc12ea0cecb.png">


For real data, we need eregs/regulations-parser#262 and eregs/notice-and-comment#187