### PR TITLE
Read Mode content width

### DIFF
--- a/regulations/static/regulations/css/less/module/comment-media-queries.less
+++ b/regulations/static/regulations/css/less/module/comment-media-queries.less
@@ -47,6 +47,11 @@ comment-media-queries.less contains media query styles for Notice and Comment
   }
 }
 
+@media only screen and ( max-width: 1100px ) {
+  #preamble-read .activate-write {
+    right: -275px;
+  }
+}
 
 // tablet + mobile screen sizes
 @media only screen and ( max-width: 780px ) {
@@ -58,11 +63,30 @@ comment-media-queries.less contains media query styles for Notice and Comment
 
   #preamble-read {
     padding-left: 0;
-  }
+    width: 100%;
 
-  .activate-write {
-    right: -60px;
-    width: 220px;
+    .not-called-out {
+      .activate-write {
+        display: block;
+      }
+    }
+
+    .activate-write {
+      padding: 5px 0;
+      position: relative;
+      right: 0;
+      top: 0;
+      width: 100%;
+
+      &:hover {
+        color: #4A90E2;
+      }
+    }
+
+    p + .activate-write {
+      display: block;
+      top: 0;
+    }
   }
 
   #preamble-write {
@@ -122,22 +146,6 @@ comment-media-queries.less contains media query styles for Notice and Comment
     font-size: 30px;
   }
 
-  .activate-write {
-    padding: 5px 0;
-    position: relative;
-    right: 0;
-    top: 0;
-    width: 100%;
-
-    &:hover {
-      color: #4A90E2;
-    }
-  }
-
-  p + .activate-write {
-    top: 0;
-  }
-
   #preamble-read {
     padding-left: 0;
 
@@ -152,9 +160,6 @@ comment-media-queries.less contains media query styles for Notice and Comment
       h4 {
         margin-top: 0;
       }
-    }
-    p + .activate-write {
-      display: block;
     }
 
     .node {

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -11,6 +11,7 @@ Preamble Read Mode
 #preamble-read {
   margin: 0;
   padding: 0 0 0 15px;
+  width: 75%;
   word-wrap: break-word;
 
   // for hiding write comment links on paragraphs
@@ -35,7 +36,7 @@ Preamble Read Mode
     font-size: 14px;
     font-weight: bold;
     position: absolute;
-    right: -100px;
+    right: -320px;
     top: -5px;
     width: 250px;
 
@@ -114,10 +115,6 @@ Preamble Read Mode
     line-height: 24px;
     padding-top: 15px;
     width: 75%;
-  }
-
-  .node {
-    padding-right: 200px;
   }
 }
 


### PR DESCRIPTION
Set `#preamble-read` width to 75%, so excerpts, footnotes, and the footer links do not take up full page width.

<img width="996" alt="screen shot 2016-05-17 at 4 31 07 pm" src="https://cloud.githubusercontent.com/assets/24054/15343246/0f4c3c0a-1c50-11e6-9e36-d17645f9badd.png">
<img width="1001" alt="screen shot 2016-05-17 at 4 31 18 pm" src="https://cloud.githubusercontent.com/assets/24054/15343248/12fd9c5e-1c50-11e6-903d-a80556d3791d.png">
