### PR TITLE
Clean JS for Review disclaimer show more/less toggles

### DIFF
--- a/regulations/static/regulations/css/less/module/comment-review.less
+++ b/regulations/static/regulations/css/less/module/comment-review.less
@@ -244,10 +244,6 @@ comment-review.less contains styles for Review Your Comment page
       list-style-type: disc;
     }
 
-    .disclaimer-text {
-      display: none;
-    }
-
     p {
       font-size: 12px;
       line-height: 18px;
@@ -274,10 +270,6 @@ comment-review.less contains styles for Review Your Comment page
       .text-expand {
         font-size: 13px;
         padding: 0 3px;
-      }
-
-      .show-more-toggle-close {
-        display: none;
       }
     }
   }

--- a/regulations/static/regulations/css/less/module/comment-review.less
+++ b/regulations/static/regulations/css/less/module/comment-review.less
@@ -244,6 +244,10 @@ comment-review.less contains styles for Review Your Comment page
       list-style-type: disc;
     }
 
+    .disclaimer-text {
+      display: none;
+    }
+
     p {
       font-size: 12px;
       line-height: 18px;
@@ -260,6 +264,7 @@ comment-review.less contains styles for Review Your Comment page
     .show-more-toggle {
       display: inline;
       color: @blue;
+      cursor: pointer;
       font-size: 14px;
 
       &:hover {
@@ -269,6 +274,10 @@ comment-review.less contains styles for Review Your Comment page
       .text-expand {
         font-size: 13px;
         padding: 0 3px;
+      }
+
+      .show-more-toggle-close {
+        display: none;
       }
     }
   }

--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -65,7 +65,6 @@ var CommentReviewView = Backbone.View.extend({
 
     this.initTabs();
     this.initDependencies();
-    this.initToggles();
 
     this.$form.find('[name="comments"]').val(JSON.stringify(commentData));
 
@@ -120,16 +119,6 @@ var CommentReviewView = Backbone.View.extend({
         updateOptions($(this).val());
       });
     });
-  },
-
-  initToggles: function() {
-
-    this.$el.find('.show-more-toggle').click(function () {
-      $(this).find('.show-more-toggle-open').toggle();
-      $(this).find('.show-more-toggle-close').toggle();
-      $(this).prev().toggle();
-    });
-
   },
 
   preview: function() {

--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -123,23 +123,13 @@ var CommentReviewView = Backbone.View.extend({
   },
 
   initToggles: function() {
-    function toggle($elm) {
-      var $target = $('#' + $elm.data('toggle'));
-      if ($target.is(':visible')) {
-        $target.hide();
-        $elm.html($target.data('more-text') || '<span class="fa fa-plus-circle text-expand" aria-hidden="true"></span>Show more');
-      } else {
-        $target.show();
-        $elm.html($target.data('less-text') || '<span class="fa fa-minus-circle text-expand" aria-hidden="true"></span>Show less');
-      }
-    }
-    var $toggles = this.$el.find('[data-toggle]');
-    $toggles.each(function(idx, elm) {
-      toggle($(elm));
+
+    this.$el.find('.show-more-toggle').click(function () {
+      $(this).find('.show-more-toggle-open').toggle();
+      $(this).find('.show-more-toggle-close').toggle();
+      $(this).prev().toggle();
     });
-    $toggles.on('click', function() {
-      toggle($(this));
-    });
+
   },
 
   preview: function() {

--- a/regulations/static/regulations/js/source/views/main/main-view.js
+++ b/regulations/static/regulations/js/source/views/main/main-view.js
@@ -32,6 +32,59 @@ Backbone.$ = $;
 var MainView = Backbone.View.extend({
     el: '#content-body',
 
+    events: {
+      'click .toggle .button': 'toggleElement'
+    },
+
+  /**
+   * Toggle an element
+   *
+   * An element that contains class 'toggle'
+   * will toggle class 'collapsible' via 'button' class
+   * as well as toggle button open/close elements for labeling purposes.
+   * Also toggles aria-hidden/expanded attributes for accessibility.
+   *
+   * <div class="toggle">
+   *  <div class="collapsible" aria-hidden="true"></div>
+   *  <div class="button" aria-expanded="false">
+   *   <div class="toggle-button-open" aria-hidden="false">Open</div>
+   *   <div class="toggle-button-close" aria-hidden="true">Close</div>
+   *  </div>
+   * </div>
+   *
+   */
+    toggleElement: function(e) {
+      var $target = $(e.target);
+      var $toggleEl = $target.closest('.toggle');
+      var $collapsibleEl = $toggleEl.find('.collapsible');
+      var $toggleButton = $toggleEl.find('.button');
+      var $toggleButtonOpen = $toggleButton.find('.toggle-button-open');
+      var $toggleButtonClose = $toggleButton.find('.toggle-button-close');
+
+      if ($collapsibleEl.is(':visible')) {
+        $collapsibleEl.hide();
+        $collapsibleEl.attr('aria-hidden', true);
+
+        $toggleButton.attr('aria-expanded', false);
+
+        $toggleButtonOpen.show();
+        $toggleButtonOpen.attr('aria-hidden', false);
+        $toggleButtonClose.hide();
+        $toggleButtonClose.attr('aria-hidden', true);
+      }
+      else {
+        $collapsibleEl.show();
+        $collapsibleEl.attr('aria-hidden', false);
+
+        $toggleButton.attr('aria-expanded', true);
+
+        $toggleButtonClose.show();
+        $toggleButtonClose.attr('aria-hidden', false);
+        $toggleButtonOpen.hide();
+        $toggleButtonOpen.attr('aria-hidden', true);
+      }
+    },
+
     initialize: function() {
       this.dataTables = null;
 
@@ -81,6 +134,10 @@ var MainView = Backbone.View.extend({
       }
 
       this.renderSection(null);
+
+      // hide any toggle elements
+      $('.toggle .collapsible').hide();
+      $('.toggle .toggle-button-close').hide();
     },
 
     modelmap: {


### PR DESCRIPTION
Set a click event for toggling elements in `main-view.js`.
- remove toggling code from `comment-review-view.js`
- set aria hidden/expanded attributes for accessibility
- expandable elements are hidden via js for non-js compatibility

Relies on template change on eregs/notice-and-comment#304.