### PR TITLE
N&C Homepage expandable section

### DIFF
--- a/regulations/static/regulations/js/source/helpers.js
+++ b/regulations/static/regulations/js/source/helpers.js
@@ -38,6 +38,17 @@ if (!Array.prototype.indexOf) {
   };
 }
 
+$(window).load(function () {
+
+  // notice and comment homepage expandable section
+  $('.nc-homepage .expandable .button').click(function (){
+    $(this).next().fadeToggle();
+    $(this).find('.button-close').toggle();
+    $(this).find('.button-open').toggle();
+  });
+
+});
+
 module.exports = {
     // Finds parent-most reg paragraph
     findBaseSection: function(id) {


### PR DESCRIPTION
Make the expandable section open upon click. Relies on eregs/notice-and-comment#305

<img width="835" alt="screen shot 2016-05-17 at 8 36 43 pm" src="https://cloud.githubusercontent.com/assets/24054/15346728/97bd7238-1c6f-11e6-840c-db1587ca960b.png">
---
<img width="815" alt="screen shot 2016-05-17 at 8 36 52 pm" src="https://cloud.githubusercontent.com/assets/24054/15346735/9ed4c3d2-1c6f-11e6-911a-46fc425499c2.png">
