### PR TITLE
Adding a block for paragraph markers.

### DIFF
--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -25,9 +25,11 @@
   {%if node.marked_up %}
     <p {% if node.is_collapsed %}class="collapsed"{% endif %}>
 
+      {% block paragraph_marker %}
       {% if node.paragraph_marker %}
         <span class="stripped-marker">{{node.paragraph_marker}}.</span>
       {% endif %}
+      {% endblock %}
 
       <span class="paragraph-text">
       {% if node.node_type == "appendix" %}


### PR DESCRIPTION
Per https://github.com/18F/fec-eregs/issues/18, adding a block for paragraph markers so we can override their format for fec.