### PR TITLE
Check for childview in main-view render

### DIFF
--- a/regulations/static/regulations/js/source/views/main/main-view.js
+++ b/regulations/static/regulations/js/source/views/main/main-view.js
@@ -223,7 +223,10 @@ var MainView = Backbone.View.extend({
       }
 
       this.childOptions.el = this.$el.children().get(0);
-      this.childView = new this.viewmap[this.contentType](this.childOptions);
+
+      if (this.contentType) {
+        this.childView = new this.viewmap[this.contentType](this.childOptions);
+      }
 
       // Destroy and recreate footer
       if (this.sectionFooter) {


### PR DESCRIPTION
Prevent setting of `childView` in main view if a `contentType` is not set. This prevents an error for non-viewed pages like N&C homepage.