### PR TITLE
Preamble Read width update

### DIFF
--- a/regulations/static/regulations/css/less/module/comment-media-queries.less
+++ b/regulations/static/regulations/css/less/module/comment-media-queries.less
@@ -47,6 +47,11 @@ comment-media-queries.less contains media query styles for Notice and Comment
   }
 }
 
+@media only screen and ( max-width: 1100px ) {
+  #preamble-read .activate-write {
+    right: -275px;
+  }
+}
 
 // tablet + mobile screen sizes
 @media only screen and ( max-width: 780px ) {
@@ -58,11 +63,30 @@ comment-media-queries.less contains media query styles for Notice and Comment
 
   #preamble-read {
     padding-left: 0;
-  }
+    width: 100%;
 
-  .activate-write {
-    right: -60px;
-    width: 220px;
+    .not-called-out {
+      .activate-write {
+        display: block;
+      }
+    }
+
+    .activate-write {
+      padding: 5px 0;
+      position: relative;
+      right: 0;
+      top: 0;
+      width: 100%;
+
+      &:hover {
+        color: #4A90E2;
+      }
+    }
+
+    p + .activate-write {
+      display: block;
+      top: 0;
+    }
   }
 
   #preamble-write {
@@ -122,22 +146,6 @@ comment-media-queries.less contains media query styles for Notice and Comment
     font-size: 30px;
   }
 
-  .activate-write {
-    padding: 5px 0;
-    position: relative;
-    right: 0;
-    top: 0;
-    width: 100%;
-
-    &:hover {
-      color: #4A90E2;
-    }
-  }
-
-  p + .activate-write {
-    top: 0;
-  }
-
   #preamble-read {
     padding-left: 0;
 
@@ -152,9 +160,6 @@ comment-media-queries.less contains media query styles for Notice and Comment
       h4 {
         margin-top: 0;
       }
-    }
-    p + .activate-write {
-      display: block;
     }
 
     .node {

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -71,7 +71,7 @@ Preamble Read Mode
   }
 
   p + .activate-write {
-    top: 15px;
+    top: 0;
   }
 
   // hidden content (with stars) on CFR

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -33,7 +33,7 @@ Preamble Read Mode
     bottom: 0;
     left: 0;
     position: absolute;
-    right: -200px;
+    right: -275px;
     top: 0;
   }
 

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -11,6 +11,7 @@ Preamble Read Mode
 #preamble-read {
   margin: 0;
   padding: 0 0 0 15px;
+  width: 75%;
   word-wrap: break-word;
 
   // for hiding write comment links on paragraphs
@@ -35,7 +36,7 @@ Preamble Read Mode
     font-size: 14px;
     font-weight: bold;
     position: absolute;
-    right: -100px;
+    right: -320px;
     top: -5px;
     width: 250px;
 
@@ -114,10 +115,6 @@ Preamble Read Mode
     line-height: 24px;
     padding-top: 15px;
     width: 75%;
-  }
-
-  .node {
-    padding-right: 200px;
   }
 }
 

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -29,6 +29,13 @@ Preamble Read Mode
       }
     }
   }
+  .not-called-out-extend {
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    right: -200px;
+    top: 0;
+  }
 
   // Write a comment about XXX link
   .activate-write {

--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -21,6 +21,8 @@
 {% endif %}
 
 <div class="node{% if not node.comments_calledout %} not-called-out{% endif %}">
+{% if not node.comments_calledout %}<div class="not-called-out-extend"></div>{% endif %}
+
 
   {%if node.marked_up %}
     <p {% if node.is_collapsed %}class="collapsed"{% endif %}>

--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -23,7 +23,6 @@
 <div class="node{% if not node.comments_calledout %} not-called-out{% endif %}">
 {% if not node.comments_calledout %}<div class="not-called-out-extend"></div>{% endif %}
 
-
   {%if node.marked_up %}
     <p {% if node.is_collapsed %}class="collapsed"{% endif %}>
 


### PR DESCRIPTION
Updated Preamble read widths to 80% of the page, so extracts, footnotes, and footer nav links line up nicely. To account for write a comment paragraph hovers, I added a `not-called-out-extend' div that adds extra width absolutely so hover functionality in the right 20% space still works.