### PR TITLE
Address some ToC scroll issues

### DIFF
--- a/regulations/static/regulations/js/source/helpers.js
+++ b/regulations/static/regulations/js/source/helpers.js
@@ -175,20 +175,7 @@ module.exports = {
     /**
      * Parse a preamble section ID.
      * @param {string} id Preamble section ID
-     * @example
-     * parsePreambleId('2016_02749-preamble-2016_02749-I-A')
-     * {
-     *   docId: '2016_02749',
-     *   path: ['preamble', '2016_02749', 'I'],
-     *   hash: '2016_02749-I-A'
-     * }
-     * @example
-     * parsePreambleId('2016_02749-cfr-478-32-a-1')
-     * {
-     *    docId: '2016_02749',
-     *    path: ['preamble', '2016_02749', 'cfr_changes', '478-32-a-1'],
-     *    hash: '478-32-a-1'
-     * }
+     * @see unittests for example usage
      */
     parsePreambleId: function(id) {
       var parts = id.split('-');
@@ -207,12 +194,19 @@ module.exports = {
         path = path.concat(['cfr_changes', parts.slice(0, 2).join('-')]);
         section = parts.slice(0, 2);
       }
-      return {
+      var parsed = {
         path: path,
         type: type,
-        hash: parts.join('-'),
         docId: docId,
         section: section
       };
+      /**
+       * If linking to the top-level, we don't need a hash. Otherwise, link to
+       * the beginning of the associated subsection
+       **/
+      if (parts.length > 2) {
+        parsed.hash = parts.join('-');
+      }
+      return parsed;
     }
 };

--- a/regulations/static/regulations/js/source/views/main/child-view.js
+++ b/regulations/static/regulations/js/source/views/main/child-view.js
@@ -124,7 +124,7 @@ var ChildView = Backbone.View.extend({
             var url = this.url;
 
             // if a hash has been passed in
-            if (options && typeof options.scrollToId !== 'undefined') {
+            if (options && options.scrollToId) {
                 url += '#' + options.scrollToId;
                 this.navigate(url);
                 $('html, body').scrollTop($('#' + options.scrollToId).offset().top);

--- a/regulations/static/regulations/js/source/views/main/main-view.js
+++ b/regulations/static/regulations/js/source/views/main/main-view.js
@@ -297,10 +297,8 @@ var MainView = Backbone.View.extend({
     },
 
     loaded: function() {
-        $('.main-content').removeClass('loading');
-
         // change focus to main content area when new sections are loaded
-        $('.section-focus').focus();
+        $('.main-content').removeClass('loading').focus();
         this.setHandlers();
     },
 

--- a/regulations/static/regulations/js/unittests/specs/helpers-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/helpers-spec.js
@@ -64,6 +64,39 @@ describe('Non-DOM Helper functions:', function() {
     });
 });
 
+describe('parsePreambleId', function() {
+    'use strict';
+
+    var Helpers;
+    before(function (){ Helpers = require('../../source/helpers'); });
+
+    it('parses relevant fields from the id string', function() {
+        expect(Helpers.parsePreambleId('2016_02749-preamble-2016_02749-I-A')).to.eql(
+            {
+                path: ['preamble', '2016_02749', 'I'],
+                type: 'preamble',
+                docId: '2016_02749',
+                section: ['2016_02749', 'I'],
+                hash: '2016_02749-I-A'
+            });
+
+        expect(Helpers.parsePreambleId('2016_02749-cfr-478-32-a-1')).to.eql(
+            {
+                path: ['preamble', '2016_02749', 'cfr_changes', '478-32'],
+                type: 'cfr',
+                docId: '2016_02749',
+                section: ['478', '32'],
+                hash: '478-32-a-1'
+            });
+    });
+
+    it('does not add a hash for top-level sections', function() {
+        expect(Helpers.parsePreambleId('2016_02749-preamble-2016_02749-I').hash).to.be.undefined;
+        expect(Helpers.parsePreambleId('2016_02749-cfr-478-32').hash).to.be.undefined;
+    });
+
+});
+
 describe('Version Finder Helper Functions:', function() {
     'use strict';
 

--- a/regulations/templates/regulations/appendix.html
+++ b/regulations/templates/regulations/appendix.html
@@ -5,7 +5,7 @@
 {% if c.node_type == "appendix" %}
     <section
               id="{{c.markup_id}}"
-              class="appendix-section section-focus"
+              class="appendix-section"
               data-base-version="{{version}}"
               data-page-type="appendix"
               data-label="{{c.human_label}}"

--- a/regulations/templates/regulations/regulation_text.html
+++ b/regulations/templates/regulations/regulation_text.html
@@ -5,7 +5,7 @@
 {%if c.node_type == 'regtext' %}
 <section
         id="{{c.markup_id}}"
-        class="reg-section section-focus"
+        class="reg-section"
         tabindex="0"
         data-permalink-section
         data-base-version="{{version}}"

--- a/regulations/tests/views_preamble_tests.py
+++ b/regulations/tests/views_preamble_tests.py
@@ -169,17 +169,17 @@ class PreambleToCTests(TestCase):
         self.nodes = [
             {
                 'title': 'l1',
-                'label': ['abc', '123', 'I'],
+                'label': ['doc_id', 'I'],
                 'children': [
                     {
                         'title': 'l2',
-                        'label': ['abc', '123', 'I', 'A'],
+                        'label': ['doc_id', 'I', 'A'],
                     }
                 ]
             },
             {
                 'title': 'l2',
-                'label': ['abc', '123', 'II'],
+                'label': ['doc_id', 'II'],
             },
         ]
 
@@ -191,14 +191,14 @@ class PreambleToCTests(TestCase):
                 preamble.PreambleSect(
                     depth=1,
                     title='l1',
-                    url='/preamble/abc/123#abc-123-I',
-                    full_id='abc-preamble-abc-123-I',
+                    url='/preamble/doc_id/I',
+                    full_id='doc_id-preamble-doc_id-I',
                     children=[
                         preamble.PreambleSect(
                             depth=2,
                             title='l2',
-                            url='/preamble/abc/123#abc-123-I-A',
-                            full_id='abc-preamble-abc-123-I-A',
+                            url='/preamble/doc_id/I#doc_id-I-A',
+                            full_id='doc_id-preamble-doc_id-I-A',
                             children=[],
                         )
                     ]
@@ -206,8 +206,8 @@ class PreambleToCTests(TestCase):
                 preamble.PreambleSect(
                     depth=1,
                     title='l2',
-                    url='/preamble/abc/123#abc-123-II',
-                    full_id='abc-preamble-abc-123-II',
+                    url='/preamble/doc_id/II',
+                    full_id='doc_id-preamble-doc_id-II',
                     children=[]
                 ),
             ],
@@ -221,13 +221,13 @@ class PreambleToCTests(TestCase):
         toc = preamble.make_preamble_toc(self.nodes)
 
         nav = preamble.section_navigation(
-            toc, [], full_id='abc-preamble-abc-123-I')
-        assert_equal(nav['next'].section_id, 'abc-preamble-abc-123-II')
+            toc, [], full_id='doc_id-preamble-doc_id-I')
+        assert_equal(nav['next'].section_id, 'doc_id-preamble-doc_id-II')
         assert_is_none(nav['previous'])
 
         nav = preamble.section_navigation(
-            toc, [], full_id='abc-preamble-abc-123-II')
-        assert_equal(nav['previous'].section_id, 'abc-preamble-abc-123-I')
+            toc, [], full_id='doc_id-preamble-doc_id-II')
+        assert_equal(nav['previous'].section_id, 'doc_id-preamble-doc_id-I')
         assert_is_none(nav['next'])
 
 

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -241,33 +241,30 @@ class PreambleSect(namedtuple('PreambleSect',
 
 
 def make_preamble_toc(nodes, depth=1, max_depth=3):
+    toc = []
     intro_subheader = depth == 2 and any('intro' in n['label'] for n in nodes)
     if depth > max_depth or intro_subheader:
-        return []
-    return [
-        PreambleSect(
-            depth=depth,
-            title=node['title'],
-            url='{}#{}'.format(
-                reverse(
-                    'chrome_preamble',
-                    kwargs={'paragraphs': '/'.join(node['label'][:2])},
-                ),
-                '-'.join(node['label']),
-            ),
-            full_id='{}-preamble-{}'.format(
-                node['label'][0],
-                '-'.join(node['label']),
-            ),
+        return toc
+
+    have_titles = [n for n in nodes if n.get('title')]
+    for node in have_titles:
+        url = reverse('chrome_preamble',
+                      kwargs={'paragraphs': '/'.join(node['label'][:2])})
+        # "Top" level ToC entries link to the top of the page
+        if len(node['label']) > 2:
+            url += '#' + '-'.join(node['label'])
+
+        toc.append(PreambleSect(
+            depth=depth, title=node['title'], url=url,
+            full_id='{}-preamble-{}'.format(node['label'][0],
+                                            '-'.join(node['label'])),
             children=make_preamble_toc(
                 node.get('children', []),
                 depth=depth + 1,
                 max_depth=max_depth,
             )
-        )
-        for node in nodes
-        if node.get('title')
-    ]
+        ))
+    return toc
 
 
 def section_navigation(preamble_toc, cfr_toc, **ids):

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -250,7 +250,8 @@ def make_preamble_toc(nodes, depth=1, max_depth=3):
     for node in have_titles:
         url = reverse('chrome_preamble',
                       kwargs={'paragraphs': '/'.join(node['label'][:2])})
-        # "Top" level ToC entries link to the top of the page
+        # Add a hash to a specific section if we're not linking to the
+        # top-level entry
         if len(node['label']) > 2:
             url += '#' + '-'.join(node['label'])
 


### PR DESCRIPTION
Previously, when clicking the top-level (e.g. I, II, III) section in the ToC, the page would load slightly scrolled down (eregs/notice-and-comment#224). We'd see something similar when clicking through the CFR changes (where we'd scroll past the amendment and subpart info, eregs/notice-and-comment#296). This should solve both problems by linking (in both markup and JS) to the _top_ of the page.

Solves eregs/notice-and-comment#224 and eregs/notice-and-comment#296