### PR TITLE
Responsive updates for mobile

### DIFF
--- a/regulations/static/regulations/css/less/module/comment-media-queries.less
+++ b/regulations/static/regulations/css/less/module/comment-media-queries.less
@@ -268,13 +268,29 @@ comment-media-queries.less contains media query styles for Notice and Comment
   #comment-review {
     padding-left: 0;
 
+    .comments ul {
+      margin: 0 0 1em 0;
+    }
+
     .edit-comment {
       position: relative;
       right: 0;
       top: 5px;
     }
+
     .download-comment .details {
       font-size: 12px;
+    }
+
+    .additional-info {
+
+      .tabs {
+        margin-bottom: 5px;
+      }
+
+      .btn-group div {
+        margin-bottom: 5px;
+      }
     }
   }
   .section-nav .previous {

--- a/regulations/static/regulations/css/less/module/comment-media-queries.less
+++ b/regulations/static/regulations/css/less/module/comment-media-queries.less
@@ -238,16 +238,31 @@ comment-media-queries.less contains media query styles for Notice and Comment
     }
 
     .comment-controls {
-      margin-bottom: 5px;
+      float: none;
+      margin-bottom: 10px;
+      width: 100%;
+
+      button, div {
+        float: none;
+      }
+    }
+
+    .comment-submission {
+      width: 100%;
+      float: none;
     }
 
     .comment-button {
       float: none;
     }
-  }
-  .comment-submission {
-    width: 100%;
-    float: none;
+
+    .comment-wrapper .status {
+      text-align: left;
+    }
+
+    a.comment-index-review {
+      float: left;
+    }
   }
 
   #comment-review {

--- a/regulations/static/regulations/css/less/module/comment-media-queries.less
+++ b/regulations/static/regulations/css/less/module/comment-media-queries.less
@@ -48,6 +48,11 @@ comment-media-queries.less contains media query styles for Notice and Comment
 }
 
 @media only screen and ( max-width: 1100px ) {
+
+  .header-main {
+    margin-right: 0;
+  }
+
   #preamble-read .activate-write {
     right: -275px;
   }
@@ -69,6 +74,10 @@ comment-media-queries.less contains media query styles for Notice and Comment
       .activate-write {
         display: block;
       }
+    }
+
+    .not-called-out-extend {
+      display: none;
     }
 
     .activate-write {
@@ -115,6 +124,18 @@ comment-media-queries.less contains media query styles for Notice and Comment
 // mobile screen size
 @media only screen and ( max-width: 480px ) {
 
+  .sub-head {
+    line-height: 33px;
+
+    .wayfinding {
+      height: 33px;
+
+      .header-label {
+        margin-left: 0;
+      }
+    }
+  }
+
   .preamble-sub-head {
     height: 35px;
 
@@ -124,6 +145,7 @@ comment-media-queries.less contains media query styles for Notice and Comment
   }
 
   .preamble-header {
+    background: @bg_gray;
     left: 40px;
     z-index: 10;
 
@@ -137,9 +159,19 @@ comment-media-queries.less contains media query styles for Notice and Comment
 
     .read-proposal,
     .write-comment {
+      border-bottom: 1px solid @medium_gray;
+      border-top: 1px solid @medium_gray;
       font-size: 13px;
       width: 50% !important;
     }
+
+    .active-mode {
+      border-bottom: none;
+    }
+  }
+
+  .preamble-wrapper {
+    padding-top: 85px;
   }
 
   h3.section-title {


### PR DESCRIPTION
Updated responsive layouts to account for recent changes since last mobile update:

<img width="334" alt="screen shot 2016-05-23 at 11 29 29 am" src="https://cloud.githubusercontent.com/assets/24054/15480369/0e649c2c-20da-11e6-862e-aba4d788d9e0.png">
<img width="330" alt="screen shot 2016-05-23 at 11 29 49 am" src="https://cloud.githubusercontent.com/assets/24054/15480372/113b8bc2-20da-11e6-8007-5f0dec506dec.png">
<img width="330" alt="screen shot 2016-05-23 at 11 30 16 am" src="https://cloud.githubusercontent.com/assets/24054/15480378/12d4f7de-20da-11e6-9e6d-5c67e15d36d5.png">
