### PR TITLE
Fix scroll-related issues with integration tests

### DIFF
--- a/regulations/uitests/diff_test.py
+++ b/regulations/uitests/diff_test.py
@@ -28,7 +28,7 @@ class DiffTest(BaseTest, unittest.TestCase):
                 '#timeline:not(.hidden)'))
 
         # drawer button should be active
-        self.assertTrue('current' in drawer_button.get_attribute('class'))
+        self.assertIn('current', drawer_button.get_attribute('class'))
 
         diff_field = self.driver.find_element_by_css_selector(
             '#timeline .status-list:nth-child(2) form select')
@@ -43,10 +43,10 @@ class DiffTest(BaseTest, unittest.TestCase):
 
         WebDriverWait(self.driver, 60)
         # make sure the url is right
-        self.assertEqual(
-            self.driver.current_url,
+        self.assertTrue(self.driver.current_url.startswith(
             self.test_url
-            + '/diff/1005-2/2012-12121/2011-11111?from_version=2011-11111')
+            + '/diff/1005-2/2012-12121/2011-11111?from_version=2011-11111'),
+            self.driver.current_url)
 
         WebDriverWait(self.driver, 60)
 
@@ -97,5 +97,5 @@ class DiffTest(BaseTest, unittest.TestCase):
 
         # make sure it goes back to the right place
         WebDriverWait(self.driver, 30).until(
-            lambda driver:
-            driver.current_url == self.test_url + '/1005-3/2011-11111')
+            lambda driver: driver.current_url.startswith(
+                self.test_url + '/1005-3/2011-11111'))

--- a/regulations/uitests/navigation_test.py
+++ b/regulations/uitests/navigation_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import unittest
 
 from selenium.webdriver.support.ui import WebDriverWait
@@ -18,11 +19,12 @@ class NavigationTest(BaseTest, unittest.TestCase):
         self.driver.execute_script(
             'poffset = document.getElementById("1005-5-b-2").offsetTop')
         self.driver.execute_script('window.scrollTo(0, poffset)')
+
         # wayfinding header should update
-        WebDriverWait(self.driver, 30).until(
-            lambda driver: driver.find_element_by_xpath(
-                '//*[@id="active-title"]').text in (u'\u00A7 1005.5(b)(1)',
-                                                    u'\u00A7 1005.5(b)'))
+        self.driver.implicitly_wait(5)
+        header = self.driver.find_element_by_css_selector('#active-title')
+        self.assertIn(header.text,
+                      (u'§ 1005.5(b)', u'§ 1005.5(b)(1)', u'§ 1005.5(b)(2)'))
 
         fwd_link = self.driver.find_element_by_css_selector('li.next a')
         fwd_link.click()


### PR DESCRIPTION
A recent change altered the size of the header, which affects where the user's
focus is centered. This changeset aligns a few of the uitests to account for
slightly different hashes and scroll positions.