### PR TITLE
Use label instead of button for file uploads

### DIFF
--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -33,9 +33,9 @@
               <div class="editor-container"></div>
               <div class="comment-controls">
                 <div class="comment-attachments"></div>
-                <button class="comment-upload-button file-upload">
+                <label class="comment-upload-button file-upload">
                   Upload Attachment<input type="file" multiple/>
-                </button>
+                </label>
                 <div class="comment-attachment-count"></div>
                 <div class="comment-attachment-limit"></div>
               </div>


### PR DESCRIPTION
The button tag submits the form rather than triggering the attachment. Using
label is more semantic and works correctly in IE11 as well as Chrome.

Resolves eregs/notice-and-comment#318