### PR TITLE
Export jQuery to window

### DIFF
--- a/regulations/static/regulations/js/source/regulations.js
+++ b/regulations/static/regulations/js/source/regulations.js
@@ -1,7 +1,7 @@
 // Launches app
 'use strict';
 // make jQuery globally accessible for plugins and analytics
-global.$ = global.jQuery = require('jquery');
+window.$ = window.jQuery = require('jquery');
 var app = require('./app-init');
 
 // A `bind()` polyfill


### PR DESCRIPTION
`regulations-site` already includes jQuery and exports it as a global for all the `regulations-site` javascript. However, if you're customizing eRegs with your own additional javascript bundle, you would have to include your own jQuery lib. By exporting jQuery to window, you have the option to reuse the existing `regulations-site` jQuery library.