### PR TITLE
Align -site with -parser's notice output

### DIFF
--- a/local_settings_test.py
+++ b/local_settings_test.py
@@ -70,11 +70,12 @@ PREAMBLE_INTRO = {
             "title": ("Addition of a Subsurface Intrusion Component to the "
                       "Hazard Ranking System"),
             "comments_close": future.isoformat(),
-            "publication": "2016-02-29",
-            "cfr_parts": [{"title": "40", "parts": ["300"]}],
+            "publication_date": "2016-02-29",
+            "cfr_title": 40,
+            "cfr_parts": ["300"],
             "dockets": ["EPA-HQ-SFUND-2010-1086",
                         "FRL-9925-69-OLEM"],
-            "rins": ["2050-AG67"],
+            "regulation_id_numbers": ["2050-AG67"],
         }
     }
 }

--- a/regulations/templates/regulations/comment-write-closed.html
+++ b/regulations/templates/regulations/comment-write-closed.html
@@ -8,7 +8,7 @@
   <div>
     <a href="#">Visit the docket ({{meta.dockets|join:"; "}})</a> to view all the public comments on this rule:
     <div>
-      {% for title_info in meta.cfr_parts %}
+      {% for title_info in meta.cfr_refs %}
         {{title_info.title}} CFR Parts {{title_info.parts|join:", "}}<br />
       {% endfor %}
     </div>

--- a/regulations/templates/regulations/tree/preamble_intro.html
+++ b/regulations/templates/regulations/tree/preamble_intro.html
@@ -29,7 +29,7 @@
       {% endif %}
     <h5>Comment period {% if meta.accepts_comments %}closes{% else %}closed{% endif %} on {{ meta.comments_close|date:"F j, Y" }} at 11:59pm
         EST.</h5>
-      Rule published {{ meta.publication|date:"F j, Y"}}
+      Rule published {{ meta.publication_date|date:"F j, Y"}}
     </div>
     {% if meta.supporting_documents %}
     <div class="view-supporting-docs">
@@ -38,11 +38,11 @@
     {% endif %}
     <hr />
     <p>
-      {% for title_info in meta.cfr_parts %}
+      {% for title_info in meta.cfr_refs %}
         {{title_info.title}} CFR Parts {{ title_info.parts|join:", " }}<br />
       {% endfor %}
       {{meta.dockets|join:"; "}}<br />
-      {{meta.rins|join:"; "}}
+      {{meta.regulation_id_numbers|join:"; "}}
     </p>
   </div>
 </li>

--- a/regulations/tests/views_preamble_tests.py
+++ b/regulations/tests/views_preamble_tests.py
@@ -113,15 +113,16 @@ class PreambleViewTests(TestCase):
         ApiReader.return_value.notice.return_value = {
             "action": "Proposed rule",
             "agencies": ["Environmental Protection Agency"],
-            "cfr_parts": [{"title": "40", "parts": ["300"]}],
+            "cfr_title": 40,
+            "cfr_parts": ["300"],
             "comments_close": future.isoformat(),
             "dockets": ["EPA-HQ-SFUND-2010-1086",
                         "FRL-9925-69-OLEM"],
             "primary_agency": "Environmental Protection Agency",
             "title": ("Addition of a Subsurface Intrusion Component to the "
                       "Hazard Ranking System"),
-            "publication": "2016-02-29",
-            "rins": ["2050-AG67"],
+            "publication_date": "2016-02-29",
+            "regulatory_id_numbers": ["2050-AG67"],
         }
         my_preamble, meta, _ = preamble.notice_data('1')
         assert_true(meta['accepts_comments'])
@@ -177,13 +178,15 @@ class PreambleViewTests(TestCase):
         """We should try to fetch data corresponding to both the Preamble and
         the Notice"""
         ApiReader.return_value.preamble.return_value = self._mock_preamble
-        ApiReader.return_value.notice.return_value = {'some': 'notice'}
+        ApiReader.return_value.notice.return_value = {
+            'cfr_title': 21, 'cfr_parts': ['123']}
 
         for doc_id in ('123_456', '123-456'):
             preamble_, meta, notice = preamble.notice_data(doc_id)
             self.assertEqual(preamble_, self._mock_preamble)
-            self.assertEqual({'accepts_comments': False}, meta)
-            self.assertEqual({'some': 'notice'}, notice)
+            self.assertFalse(meta['accepts_comments'])
+            self.assertEqual(meta['cfr_refs'],
+                             [{'title': 21, 'parts': ['123']}])
             self.assertEqual(ApiReader.return_value.preamble.call_args[0][0],
                              '123_456')
             self.assertEqual(ApiReader.return_value.notice.call_args[0][0],

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -340,6 +340,12 @@ def notice_data(doc_number):
     else:
         meta['accepts_comments'] = False
 
+    # We don't pass along cfr_ref information in a super useful format, yet.
+    # Construct one here:
+    if 'cfr_refs' not in meta and 'cfr_title' in meta and 'cfr_parts' in meta:
+        meta['cfr_refs'] = [{"title": meta['cfr_title'],
+                             "parts": meta['cfr_parts']}]
+
     return preamble, meta, notice
 
 


### PR DESCRIPTION
As we were using mock data to represent notices for several weeks, field names
were a bit out of sync. Now that we have real data, make sure we're using the
proper fields.

This also constructs a `cfr_refs` field. We probably want to add such a
structure to the parsed notices at some point, but we can punt for a bit.