### PR TITLE
Add step modifying close date of example notice

### DIFF
--- a/dummy_api/start.sh
+++ b/dummy_api/start.sh
@@ -15,4 +15,10 @@ docker run --rm -it -v $PWD/cache:/app/cache eregs/parser notice_preamble 2016-0
 docker run --rm -it -v $PWD/cache:/app/cache eregs/parser layers
 docker run --rm -it -v $PWD/cache:/app/cache --link core:core eregs/parser write_to http://core:8080
 
+# Modify the close date
+curl http://localhost:8282/notice/2016-02749 | python -m json.tool > original-notice.json
+FUTURE=`date --date="1 month" +"%Y-%m-%d"`
+sed -i "s/2016-04-29/$FUTURE/g" original-notice.json > modified-notice.json
+curl -X PUT http://localhost:8282/notice/2016-02749 -d @modified-notice.json
+
 docker logs core


### PR DESCRIPTION
It's very hard to test commenting on a notice when it's already closed

Resolves #375 