### PR TITLE
Write Comment Excerpt Toggling

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -320,6 +320,7 @@ Write Mode
     border-radius: 2px;
     box-shadow: 0 0 1px 1px @text_area_border;
     margin: 30px 0;
+    position: relative;
   }
 
   .comment-context-toggle {
@@ -357,7 +358,7 @@ Write Mode
     margin: 0 0 25px 0;
     max-height: 400px;
     overflow: auto;
-    padding-right: 25px;
+    padding: 0 20px;
 
     ul {
       padding-left: 0;

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -265,7 +265,6 @@ Write Mode
     }
   }
 
-
   .comment-controls {
     float: left;
     padding-bottom: 35px;
@@ -317,16 +316,53 @@ Write Mode
     }
   }
 
-  .comment-context {
-    margin: 0 0 25px 0;
-    padding: 0 20px;
-    max-height: 400px;
-    overflow: auto;
-    border: 1px solid transparent;
+  .comment-context-wrapper {
+    border-radius: 2px;
     box-shadow: 0 0 1px 1px @text_area_border;
-    border-radius: 2px
+    margin: 30px 0;
   }
 
+  .comment-context-toggle {
+    background-color: @grey;
+    border-radius: 2px;
+    cursor: pointer;
+    font-size: 16px;
+    padding: 10px 15px;
+
+    .comment-context-text {
+      color: @blue;
+    }
+
+    .fa-minus-circle,
+    .comment-context-text-less {
+      display: none;
+    }
+
+    .fa {
+      margin-right: 3px;
+    }
+
+    .comment-context-label {
+      font-weight: bold;
+    }
+
+    .comment-context-type {
+      text-transform: capitalize;
+    }
+  }
+
+  .comment-context {
+    border-top: 1px solid @text_area_border;
+    display: none;
+    margin: 0 0 25px 0;
+    max-height: 400px;
+    overflow: auto;
+    padding-right: 25px;
+
+    ul {
+      padding-left: 0;
+    }
+  }
 }
 
 .comment-index {

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -346,10 +346,6 @@ Write Mode
     .comment-context-label {
       font-weight: bold;
     }
-
-    .comment-context-type {
-      text-transform: capitalize;
-    }
   }
 
   .comment-context {

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -267,8 +267,9 @@ Write Mode
 
 
   .comment-controls {
-    width: 70%;
     float: left;
+    padding-bottom: 35px;
+    width: 70%;
 
     button {
       float: left;

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -51,6 +51,7 @@ var CommentView = Backbone.View.extend({
     this.options = options;
 
     this.$context = this.$el.find('.comment-context');
+    this.$contextSectionLabel = this.$el.find('.comment-context-section');
     this.$header = this.$el.find('.comment-header');
     this.$container = this.$el.find('.editor-container');
     this.$input = this.$el.find('input[type="file"]');
@@ -111,6 +112,9 @@ var CommentView = Backbone.View.extend({
         $sectionHeader.remove();
       }
       this.$header.append('<a href="' + href + '">' + label + '</a>');
+
+      this.$contextSectionLabel.empty().html(options.label);
+
       this.$context.append(options.$parent);
     }
   },

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -43,6 +43,7 @@ var CommentView = Backbone.View.extend({
     'dragenter input[type="file"]': 'highlightDropzone',
     'dragleave input[type="file"]': 'unhighlightDropzone',
     'click .comment-header': 'openComment',
+    'click .comment-context-toggle': 'toggleCommentExcerpt',
     'submit form': 'save'
   },
 
@@ -126,6 +127,14 @@ var CommentView = Backbone.View.extend({
     DrawerEvents.trigger('section:open', options.tocId);
     DrawerEvents.trigger('pane:change', type === 'preamble' ? 'table-of-contents' : 'table-of-contents-secondary');
     MainEvents.trigger('section:open', options.section, options, 'preamble-section');
+  },
+
+  toggleCommentExcerpt: function() {
+    $('.comment-context-text-more').toggle();
+    $('.comment-context-text-less').toggle();
+    $('.fa-plus-circle').toggle();
+    $('.fa-minus-circle').toggle();
+    $('.comment-context').toggle();
   },
 
   render: function() {

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -40,7 +40,13 @@
                   context for:
                 </span>
                 <span class="comment-context-label">
-                  <span class="comment-context-type">{{ type }}</span>
+                  <span class="comment-context-type">
+                  {% if type == "cfr" %}
+                    {{ type|upper }}
+                  {% else %}
+                    {{ type|capfirst }}
+                  {% endif %}
+                  </span>
                   &nbsp;|&nbsp;
                   <span class="comment-context-section"></span>
                 </span>

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -27,8 +27,29 @@
         {% if meta.accepts_comments %}
           <div class="comment">
             <h4 class="comment-header">You are writing a comment about </h4>
-            <div class="comment-context"></div>
+
+            <div class="comment-context-wrapper">
+
+              <div class="comment-context-toggle">
+                <span class="comment-context-text">
+                  <span class="fa fa-plus-circle" aria-hidden="true"></span>
+                  <span class="fa fa-minus-circle" aria-hidden="true"></span>
+                  Show
+                  <span class="comment-context-text-more">more</span>
+                  <span class="comment-context-text-less">less</span>
+                  context for:
+                </span>
+                <span class="comment-context-label">
+                  <span class="comment-context-type">{{ type }}</span> &nbsp;|&nbsp; {{ section_label }}
+                </span>
+              </div>
+
+              <div class="comment-context"></div>
+
+            </div>
+
             <h4 class="comment-header">Write your response to </h4>
+
             <form>
               <div class="editor-container"></div>
               <div class="comment-controls">

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -40,7 +40,9 @@
                   context for:
                 </span>
                 <span class="comment-context-label">
-                  <span class="comment-context-type">{{ type }}</span> &nbsp;|&nbsp; {{ section_label }}
+                  <span class="comment-context-type">{{ type }}</span>
+                  &nbsp;|&nbsp;
+                  <span class="comment-context-section"></span>
                 </span>
               </div>
 


### PR DESCRIPTION
As described in eregs/notice-and-comment#202, implement toggling of the section excerpt.

Default closed:
<img width="927" alt="screen shot 2016-06-01 at 11 53 46 pm" src="https://cloud.githubusercontent.com/assets/24054/15736400/5358ac52-2854-11e6-9f55-3c205a3b686d.png">
 
Click to reveal excerpt:
<img width="930" alt="screen shot 2016-06-01 at 11 54 23 pm" src="https://cloud.githubusercontent.com/assets/24054/15736410/5dddccca-2854-11e6-8d1d-781f5d41b6ca.png">
