### PR TITLE
Removing line between form fields and disclaimer

### DIFF
--- a/regulations/static/regulations/css/less/module/comment-review.less
+++ b/regulations/static/regulations/css/less/module/comment-review.less
@@ -140,12 +140,10 @@ comment-review.less contains styles for Review Your Comment page
   }
 
   .additional-info {
-    padding: 0 0 25px 0;
     max-width: 535px;
-    border-bottom: 2px solid @light_field;
 
     .tabs {
-      margin: 10px 0;
+      margin: 10px 0 5px;
     }
 
     .btn-group {
@@ -184,6 +182,10 @@ comment-review.less contains styles for Review Your Comment page
 
     .labeled-field {
       margin: 5px 0;
+
+      &:first-child {
+        margin: 15px 0 5px;
+      }
     }
 
     .select-dropdown {
@@ -247,8 +249,7 @@ comment-review.less contains styles for Review Your Comment page
   }
 
   .statement {
-    padding: 10px 0 0;
-    margin: 5px 0 30px 0;
+    margin: 0 0 30px 0;
     max-width: 620px;
 
     .required {


### PR DESCRIPTION
This removes the line between the form fields and disclaimer so it doesn't look like something failed to load when "myself" is selected.

![screen shot 2016-06-02 at 12 58 05 pm](https://cloud.githubusercontent.com/assets/776987/15756828/930e66ba-28c8-11e6-9e44-35cb15960b05.png)
![screen shot 2016-06-02 at 12 57 58 pm](https://cloud.githubusercontent.com/assets/776987/15756829/9315e156-28c8-11e6-812d-ddb7217fabf3.png)
