### PR TITLE
Fix "edit this comment" linking

### DIFF
--- a/regulations/static/regulations/js/source/views/main/preamble-view.js
+++ b/regulations/static/regulations/js/source/views/main/preamble-view.js
@@ -27,6 +27,7 @@ var PreambleView = ChildView.extend({
     var type = parsed.type;
 
     this.options.scrollToId = parsed.hash;
+
     this.url = parsed.path.join('/');
 
     ChildView.prototype.initialize.apply(this, arguments);
@@ -94,6 +95,7 @@ var PreambleView = ChildView.extend({
     $parent = $parent.is('[data-page-type]') ?
       this.$read.find('.preamble-content') :
       $parent;
+
     $parent = $parent.clone();
     $parent.find('.activate-write').remove();
 
@@ -134,7 +136,9 @@ var PreambleView = ChildView.extend({
 
     if (this.options.mode === 'write') {
       var $parent = $('#' + this.options.scrollToId);
-      this.write(this.options.section, this.options.tocId, this.options.label, $parent);
+      var indexes = $parent.data('indexes');
+
+      this.write(this.options.section, this.options.tocId, indexes, this.options.label, $parent);
     } else {
       this.handleRead();
     }


### PR DESCRIPTION
Clicking the edit icon on Comment Index and "edit this comment" on Review your full comment pages was broken. I fixed this by passing the missing `indexes` variable to the `write` function when write mode is initialized upon preamble section load.