### PR TITLE
Set internal links in Write Mode

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -370,7 +370,7 @@ Write Mode
 .comment-header {
   margin: 0.6em 0;
 
-  & > a {
+  .comment-header-link a {
     color: @black;
     border-bottom: 2px solid fade(@blue, 80%);
   }

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -53,6 +53,7 @@ var CommentView = Backbone.View.extend({
     this.$context = this.$el.find('.comment-context');
     this.$contextSectionLabel = this.$el.find('.comment-context-section');
     this.$header = this.$el.find('.comment-header');
+    this.$headerLink = this.$el.find('.comment-header-link');
     this.$container = this.$el.find('.editor-container');
     this.$input = this.$el.find('input[type="file"]');
     this.$attachmentCount = this.$el.find('.comment-attachment-count');
@@ -111,9 +112,9 @@ var CommentView = Backbone.View.extend({
         label = [label, $sectionHeader.text().split('. ').slice(1)].join('. ');
         $sectionHeader.remove();
       }
-      this.$header.append('<a href="' + href + '">' + label + '</a>');
+      this.$headerLink.html('<a href="' + href + '">' + label + '</a>');
 
-      this.$contextSectionLabel.empty().html(options.label);
+      this.$contextSectionLabel.html(options.label);
 
       this.$context.append(options.$parent);
     }

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -26,7 +26,10 @@
       <div class="comment-wrapper">
         {% if meta.accepts_comments %}
           <div class="comment">
-            <h4 class="comment-header">You are writing a comment about </h4>
+            <h4 class="comment-header">
+              You are writing a comment about
+              <span class="comment-header-link"></span>
+            </h4>
 
             <div class="comment-context-wrapper">
 
@@ -56,7 +59,10 @@
 
             </div>
 
-            <h4 class="comment-header">Write your response to </h4>
+            <h4 class="comment-header">
+              Write your response to
+              <span class="comment-header-link"></span>
+            </h4>
 
             <form>
               <div class="editor-container"></div>


### PR DESCRIPTION
Wrap internal links in Write Mode in a span to be replaced rather than appending the links to `h4.comment-header`. This prevents multiple links from appearing as noted in eregs/notice-and-comment#308