### PR TITLE
Write mode fixes

### DIFF
--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -47,7 +47,7 @@ var CommentReviewView = Backbone.View.extend({
 
   editComment: function(e) {
     var section = $(e.target).closest('li').data('section');
-    var label = $(e.target).closest('li').find('.comment-section-label').data('section-label');
+    var label = $(e.target).closest('li').find('.comment-section-label').text();
     var options = {id: section, section: section, label: label, mode: 'write'};
 
     $('#content-body').removeClass('comment-review-wrapper');

--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -47,7 +47,8 @@ var CommentReviewView = Backbone.View.extend({
 
   editComment: function(e) {
     var section = $(e.target).closest('li').data('section');
-    var options = {id: section, section: section, mode: 'write'};
+    var label = $(e.target).closest('li').find('.comment-section-label').data('section-label');
+    var options = {id: section, section: section, label: label, mode: 'write'};
 
     $('#content-body').removeClass('comment-review-wrapper');
 

--- a/regulations/static/regulations/js/source/views/main/preamble-view.js
+++ b/regulations/static/regulations/js/source/views/main/preamble-view.js
@@ -127,6 +127,9 @@ var PreambleView = ChildView.extend({
 
     this.$read.hide();
     this.$write.show();
+
+    // set anchor to top of page
+    $('body').scrollTop(0);
   },
 
   renderComments: function() {

--- a/regulations/templates/regulations/comment-review-chrome.html
+++ b/regulations/templates/regulations/comment-review-chrome.html
@@ -16,7 +16,7 @@
         <ul>
           <% _.each(comments, function(comment, index) { %>
             <li data-section="<%= comment.id %>">
-              <h4><%= comment.label %></h4>
+              <h4 class="comment-section-label" data-section-label="<%= comment.label %>"><%= comment.label %></h4>
               <div class="comment-content">
                 <%= comment.commentHtml %>
               </div>

--- a/regulations/templates/regulations/comment-review-chrome.html
+++ b/regulations/templates/regulations/comment-review-chrome.html
@@ -16,7 +16,7 @@
         <ul>
           <% _.each(comments, function(comment, index) { %>
             <li data-section="<%= comment.id %>">
-              <h4 class="comment-section-label" data-section-label="<%= comment.label %>"><%= comment.label %></h4>
+              <h4 class="comment-section-label"><%= comment.label %></h4>
               <div class="comment-content">
                 <%= comment.commentHtml %>
               </div>


### PR DESCRIPTION
- Section labels are now passed through "edit this comment" from review page (bugfix in eregs/notice-and-comment#308)
- Write mode page loads at top of screen (setting `scrollTop(0)`). It was attempting to scroll down to a lower section before.