### PR TITLE
Align wayfinding label to page content

### DIFF
--- a/regulations/static/regulations/css/less/module/comment-read.less
+++ b/regulations/static/regulations/css/less/module/comment-read.less
@@ -112,6 +112,10 @@ Preamble Read Mode
     }
   }
 
+  .cfr-wrapper {
+    padding-left: 15px;
+  }
+
   .cfr-instructions {
     .font-regular;
     font-size: 16px;

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -8,6 +8,10 @@ comment.less contains styles related to commenting on sections
 N&C Header - including Read/Write tab
 ================
 */
+.preamble-sub-head #content-header {
+  padding-left: 50px;
+}
+
 .preamble-header {
   position: absolute;
   right: 0;
@@ -72,6 +76,7 @@ Write Mode
   // Write your comment - style wrapper
   .comment-wrapper {
     .font-regular;
+    padding-left: 15px;
 
     .comment {
       font-size: 14px;

--- a/regulations/templates/regulations/cfr_changes.html
+++ b/regulations/templates/regulations/cfr_changes.html
@@ -1,37 +1,41 @@
-{% for instruction in instructions %}
-  <div class="cfr-instructions">
-    {{ instruction }}
-  </div>
-{% endfor %}
+<div class="cfr-wrapper">
 
-{% for authority in authorities %}
-  <div>
-    <strong>Authority</strong>: {{ authority }}
-  </div>
-{% endfor %}
+  {% for instruction in instructions %}
+    <div class="cfr-instructions">
+      {{ instruction }}
+    </div>
+  {% endfor %}
 
-{% for subpart in subparts %}
-<h5 class="subpart-addition">
-  <ins>Subpart {{subpart.letter}} &mdash; {{subpart.title}}</ins>
-</h5>
-<div class="subpart-info">
-  <div class="subpart-wayfinding">
-    {% for url in subpart.urls %}
-      <a href="{{url}}"
-         aria-label="{{forloop.counter}} of {{subpart.urls|length}} sections"
-         {% if forloop.counter0 == subpart.idx %}class="current"{% endif %}
-       >&nbsp;</a>
-    {% endfor %}
+  {% for authority in authorities %}
+    <div>
+      <strong>Authority</strong>: {{ authority }}
+    </div>
+  {% endfor %}
+
+  {% for subpart in subparts %}
+  <h5 class="subpart-addition">
+    <ins>Subpart {{subpart.letter}} &mdash; {{subpart.title}}</ins>
+  </h5>
+  <div class="subpart-info">
+    <div class="subpart-wayfinding">
+      {% for url in subpart.urls %}
+        <a href="{{url}}"
+           aria-label="{{forloop.counter}} of {{subpart.urls|length}} sections"
+           {% if forloop.counter0 == subpart.idx %}class="current"{% endif %}
+         >&nbsp;</a>
+      {% endfor %}
+    </div>
+    <p class="subpart-sections">This is section
+      <strong>{{subpart.idx|add:"1"}} of {{subpart.urls|length}}</strong>
+      in subpart {{subpart.letter}}
+    </p>
   </div>
-  <p class="subpart-sections">This is section
-    <strong>{{subpart.idx|add:"1"}} of {{subpart.urls|length}}</strong>
-    in subpart {{subpart.letter}}
-  </p>
+  {% endfor %}
+
+  {% if tree %}
+    {% with c=tree %}
+    {% include "regulations/regulation_text.html" %}
+    {% endwith %}
+  {% endif %}
+
 </div>
-{% endfor %}
-
-{% if tree %}
-  {% with c=tree %}
-  {% include "regulations/regulation_text.html" %}
-  {% endwith %}
-{% endif %}

--- a/regulations/templates/regulations/preamble-base.html
+++ b/regulations/templates/regulations/preamble-base.html
@@ -22,7 +22,11 @@
 {% block sub-head-class %}preamble-sub-head{% endblock %}
 
 {% block active_title %}
-  <em class="header-label">{{section_label}}</em>
+  <em class="header-label">
+    {% if section_label != None %}
+      {{ section_label }}
+    {% endif %}
+  </em>
 {% endblock %}
 
 {% block header-secondary %}

--- a/regulations/templates/regulations/preamble-base.html
+++ b/regulations/templates/regulations/preamble-base.html
@@ -23,9 +23,7 @@
 
 {% block active_title %}
   <em class="header-label">
-    {% if section_label != None %}
-      {{ section_label }}
-    {% endif %}
+    {{ section_label }}
   </em>
 {% endblock %}
 

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -478,7 +478,7 @@ class CFRChangesView(View):
             ids = {'part': label_parts[0]}
             sub_context = self.authorities_context(
                 amendments, cfr_part=section)
-            section_label = None
+            section_label = ''
         else:
             ids = {'part': label_parts[0], 'section': label_parts[1]}
             toc_position = get_toc_position(context['cfr_change_toc'], **ids)


### PR DESCRIPTION
- Set wayfinding label position back to align with preamble read content.
 - Increase padding on CFR and preamble write pages to align wayfinding label to preamble read content.
 - Fixes eregs/notice-and-comment#344
- If there is no label, set `{{ section_label }}` to `''` instead of `None` so it doesn't show up on the frontend. Fixes eregs/notice-and-comment#340

<img width="983" alt="screen shot 2016-06-06 at 5 06 13 pm" src="https://cloud.githubusercontent.com/assets/24054/15841895/7a129638-2c09-11e6-98cf-8f7825773e18.png">
<img width="992" alt="screen shot 2016-06-06 at 5 06 20 pm" src="https://cloud.githubusercontent.com/assets/24054/15841897/7c94365a-2c09-11e6-84ae-0580527d89d2.png">
<img width="1012" alt="screen shot 2016-06-06 at 5 12 59 pm" src="https://cloud.githubusercontent.com/assets/24054/15841960/ea216328-2c09-11e6-99a2-6cb37d485811.png">
