### PR TITLE
Set anchor tags for accessible tab navigation

### DIFF
--- a/regulations/static/regulations/css/less/layout.less
+++ b/regulations/static/regulations/css/less/layout.less
@@ -4,6 +4,11 @@
  layout.less defines the structural layout of the site
  */
 
+// focus for accessibliity tabbing
+a:focus {
+    border: 1px dotted @black;
+}
+
 .wrap {
     width: 100%;
 }

--- a/regulations/static/regulations/css/less/layout.less
+++ b/regulations/static/regulations/css/less/layout.less
@@ -4,11 +4,6 @@
  layout.less defines the structural layout of the site
  */
 
-// focus for accessibliity tabbing
-a:focus {
-    border: 1px dotted @black;
-}
-
 .wrap {
     width: 100%;
 }

--- a/regulations/static/regulations/css/less/module/comment-read.less
+++ b/regulations/static/regulations/css/less/module/comment-read.less
@@ -11,14 +11,14 @@ Preamble Read Mode
   // for hiding write comment links on paragraphs
   // when section is not called out for comment
   .not-called-out {
-    .activate-write {
+    .activate-write a {
       display: none;
     }
 
     // then show write comment links when paragraph
     // section is hovered
     &:hover {
-      .activate-write {
+      .activate-write a {
         display: block;
       }
     }

--- a/regulations/static/regulations/css/less/module/comment-review.less
+++ b/regulations/static/regulations/css/less/module/comment-review.less
@@ -151,7 +151,8 @@ comment-review.less contains styles for Review Your Comment page
       list-style: none;
     }
 
-    .btn-group-item {
+    a.btn-group-item {
+      color: @black;
       display: inline-block;
       background: @grey;
       font-size: 14px;

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -16,13 +16,14 @@ N&C Header - including Read/Write tab
   position: absolute;
   right: 0;
 
-  span {
+  .tab-descriptions {
+    font-size: 14px;
+    color: @dark_field;
     padding: 0 5px;
+  }
 
-    &.tab-descriptions {
-      font-size: 14px;
-      color: @dark_field;
-    }
+  a {
+    padding: 0 5px;
 
     &.hide-mobile {
       padding: 0;
@@ -187,6 +188,7 @@ Write Mode
   .comment-upload-button {
     background-color: @grey;
     color: @black;
+    cursor: pointer;
     border-radius: 2px;
     .font-regular;
     font-weight: 500;
@@ -210,6 +212,7 @@ Write Mode
     background-color: @grey;
     border-radius: 2px;
     cursor: pointer;
+    display: block;
     font-size: 16px;
     padding: 10px 15px;
 
@@ -318,6 +321,11 @@ Write Mode
       font-size: 15px;
       float: right;
       width: 40px;
+
+      a:focus .fa {
+        color: darken(@black, 10%);
+        display: inline-block;
+      }
 
       .fa {
         vertical-align: middle;

--- a/regulations/static/regulations/css/less/module/drawer-content.less
+++ b/regulations/static/regulations/css/less/module/drawer-content.less
@@ -86,7 +86,6 @@ This contains all of the styles specific to the TOC
     display: block;
     padding: 7px 15px 8px 5px;
     line-height: 1.3;
-    outline: none;
   }
 
   a:link,

--- a/regulations/static/regulations/css/less/module/drawer.less
+++ b/regulations/static/regulations/css/less/module/drawer.less
@@ -101,7 +101,6 @@ Drawer Links
     a:link,
     a:visited {
         text-decoration: none;
-        outline: none;
     }
 
     a:hover,

--- a/regulations/static/regulations/css/less/normalize.less
+++ b/regulations/static/regulations/css/less/normalize.less
@@ -19,7 +19,7 @@ hgroup,
 main,
 nav,
 section,
-summary { 
+summary {
     display: block;
 }
 
@@ -101,7 +101,8 @@ body {
  */
 
 a:focus {
-    outline: thin dotted;
+    border: none;
+    outline: 1px dotted @blue;
 }
 
 /**

--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -73,6 +73,10 @@ var CommentReviewView = Backbone.View.extend({
 
     this.$form.find('[name="comments"]').val(JSON.stringify(commentData));
 
+    // hide toggle elements
+    $('.toggle .collapsible').attr('aria-hidden', 'true').hide();
+    $('.toggle .toggle-button-close').attr('aria-hidden', 'true').hide();
+
     CommentEvents.trigger('comment:writeTabOpen');
   },
 
@@ -93,10 +97,15 @@ var CommentReviewView = Backbone.View.extend({
         }
       });
     }
+
     var $tabs = self.$el.find('[data-tab]');
     updateTabs($tabs.data('tab'), $tabs.data('tab-set'));
-    $tabs.on('click', function() {
+
+    $tabs.on('click', function(e) {
       var $tab = $(this);
+
+      e.preventDefault();
+
       updateTabs($tab.data('tab'), $tab.data('tab-set'));
     });
   },
@@ -139,7 +148,10 @@ var CommentReviewView = Backbone.View.extend({
     });
   },
 
-  preview: function() {
+  preview: function(e) {
+
+    e.preventDefault();
+
     var $xhr = $.ajax({
       type: 'POST',
       url: window.APP_PREFIX + 'comments/preview',

--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -74,8 +74,8 @@ var CommentReviewView = Backbone.View.extend({
     this.$form.find('[name="comments"]').val(JSON.stringify(commentData));
 
     // hide toggle elements
-    $('.toggle .collapsible').attr('aria-hidden', 'true').hide();
-    $('.toggle .toggle-button-close').attr('aria-hidden', 'true').hide();
+    this.$el.find('.toggle .collapsible').attr('aria-hidden', 'true').hide();
+    this.$el.find('.toggle .toggle-button-close').attr('aria-hidden', 'true').hide();
 
     CommentEvents.trigger('comment:writeTabOpen');
   },

--- a/regulations/static/regulations/js/source/views/main/main-view.js
+++ b/regulations/static/regulations/js/source/views/main/main-view.js
@@ -61,6 +61,8 @@ var MainView = Backbone.View.extend({
       var $toggleButtonOpen = $toggleButton.find('.toggle-button-open');
       var $toggleButtonClose = $toggleButton.find('.toggle-button-close');
 
+      e.preventDefault();
+
       if ($collapsibleEl.is(':visible')) {
         $collapsibleEl.hide();
         $collapsibleEl.attr('aria-hidden', true);

--- a/regulations/templates/regulations/comment-review-chrome.html
+++ b/regulations/templates/regulations/comment-review-chrome.html
@@ -35,7 +35,7 @@
                   </ul>
                 </div>
               <% } %>
-              <div class="edit-comment">
+              <a class="edit-comment" href="#">
                 <svg width="14px" height="11px" viewBox="0 0 14 11" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
                         <g class="write-icon">
@@ -44,14 +44,14 @@
                     </g>
                 </svg>
                 <span>Edit this comment</span>
-              </div>
+              </a>
             </li>
           <% }) %>
         </ul>
 
         <div class="download-comment group">
           <% if (!previewLoading) { %>
-            <h4 class="preview-button">Download the text of your full comment as a PDF</h4>
+            <h4><a class="preview-button" href="#">Download the text of your full comment as a PDF</a></h4>
           <% } else { %>
             <h4 class="preview-button" disabled>Building your PDF...</h4>
           <% } %>

--- a/regulations/templates/regulations/node.html
+++ b/regulations/templates/regulations/node.html
@@ -48,7 +48,6 @@
         data-section="{{ node.full_id }}"
         data-indexes="{{ node.indexes }}"
         data-label="{{ node.human_label }}">
-
       <a href="#">
         <span class="fa fa-pencil-square-o" aria-hidden="true"></span>
         <div class="paragraph-comment">Write a comment about {{ node.human_label }}</div>

--- a/regulations/templates/regulations/preamble-header.html
+++ b/regulations/templates/regulations/preamble-header.html
@@ -6,6 +6,6 @@
   </div>
   <div class="write-comment{% if comment_mode == 'write' %} active-mode{% endif %}">
     <span class="write-icon fa fa-pencil-square-o" aria-hidden="true"></span>
-    <span>Write <span class="hide-mobile">a comment</span></span>
+    <a href="#">Write <span class="hide-mobile">a comment</span></a>
   </div>
 </div>

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -65,7 +65,7 @@
 
             <div class="comment-context-wrapper">
 
-              <div class="comment-context-toggle">
+              <a class="comment-context-toggle" href="#">
                 <span class="comment-context-text">
                   <span class="fa fa-plus-circle" aria-hidden="true"></span>
                   <span class="fa fa-minus-circle" aria-hidden="true"></span>
@@ -85,7 +85,7 @@
                   &nbsp;|&nbsp;
                   <span class="comment-context-section"></span>
                 </span>
-              </div>
+              </a>
 
               <div class="comment-context"></div>
 
@@ -169,8 +169,8 @@
         data-comment-label="<%= comment.label %>">
       <div class="comment-index-section"><%= comment.label %></div>
       <div class="comment-index-modify">
-        <a class="comment-index-edit" title="Edit Comment"><span class="fa fa-pencil-square-o"></span></a>
-        <a class="comment-index-clear" title="Remove Comment"><span class="fa fa-times"></span></a>
+        <a class="comment-index-edit" title="Edit Comment" href="#"><span class="fa fa-pencil-square-o"></span></a>
+        <a class="comment-index-clear" title="Remove Comment" href="#"><span class="fa fa-times"></span></a>
       </div>
     </li>
   <% }); %>


### PR DESCRIPTION
General
- Clearer focus outline on links for navigation (can see some focused links in tab through that weren't visible before like CFR and Search tabs in TOC)
- "Write a comment" header link now tab accessible

Write Mode
- "Show more context" toggle section tab accessible
- Comment index: edit and delete icons are tab accessible
- Upload attachment button has `cursor: pointer`

Review your full comment
- "Edit this comment" links tab accessible
- Download PDF link tab accessible
 - also fixed a bug in which clicking download pdf would cause all the disclaimer toggle sections to open
  