### PR TITLE
Comment confirmation styling 

### DIFF
--- a/regulations/static/regulations/css/less/base-variables.less
+++ b/regulations/static/regulations/css/less/base-variables.less
@@ -10,7 +10,7 @@ variables.less contains all theme variable / variable overrides
 
 @green: #2CB34A;
 @green_midtone: #ADDC91;
-@green_light: #DBEDD4;
+@green_light: #E7F4E4;
 @uswds_green: #2F8540;
 @black: #101820;
 @white: #FFFFFF;
@@ -21,6 +21,7 @@ variables.less contains all theme variable / variable overrides
 @pacific: #0072CE;
 @blue: #0072CE;
 @link_blue: #348dc9; /* blue used for link borders and search results */
+@blue_light: #E1F3F8;
 @light_neutral: #D7D2CB;
 @dark_gray: #797D81;
 ; /* dark border */

--- a/regulations/static/regulations/css/less/module/comment-confirm.less
+++ b/regulations/static/regulations/css/less/module/comment-confirm.less
@@ -125,15 +125,32 @@ Contains styles for Comment confirmation success/fail/invalid pages.
       margin: 4px 6px 0 0;
       vertical-align: top;
     }
+
     .status {
       background-color: @blue_light;
       padding: 8px 16px;
-      margin: 16px 0;
+      margin: 0;
 
       .status-message {
         display: inline-block;
       }
     }
+
+    .status-container {
+      margin: 16px 0;
+    }
+
+    .status-waiting {
+      background-color: @blue_light;
+      padding: 8px 16px;
+      margin: 1px 0;
+
+      .waiting-message {
+        display: inline-block;
+        width: 90%;
+      }
+    }
+
     .tracking-number-retrieved {
       background-color: @green_light;
     }

--- a/regulations/static/regulations/css/less/module/comment-confirm.less
+++ b/regulations/static/regulations/css/less/module/comment-confirm.less
@@ -15,7 +15,7 @@ Contains styles for Comment confirmation success/fail/invalid pages.
   }
 
   .comment-confirm-alert {
-    padding: 10px;
+    padding: 15px 10px 10px;
 
     &.success-alert {
       background-color: @green_light;
@@ -28,6 +28,7 @@ Contains styles for Comment confirmation success/fail/invalid pages.
     .fa-check-circle,
     .fa-exclamation-circle {
       display: inline-block;
+      font-size: 34px;
       padding: 5px 15px 0;
       vertical-align: top;
     }
@@ -37,7 +38,7 @@ Contains styles for Comment confirmation success/fail/invalid pages.
       width: 90%;
     }
 
-    h2 {
+    h3 {
       margin: 0;
     }
     p {
@@ -52,15 +53,17 @@ Contains styles for Comment confirmation success/fail/invalid pages.
       color: @blue;
       font-size: 2.5em;
       display: inline-block;
-      margin: 10px 10px 10px 0;
+      margin: 10px 12px 10px 0;
       vertical-align: top;
     }
 
     .save-pdf-text {
       display: inline-block;
+      padding: 5px 0;
 
       h3 {
         font-size: 20px;
+        line-height: 26px;
         margin: 0;
       }
       a {
@@ -82,15 +85,15 @@ Contains styles for Comment confirmation success/fail/invalid pages.
   }
 
   h3 {
-    margin: 0 0 0.25em;
+    margin: 0 0 5px;
   }
 
   section {
     border-top: 1px solid @medium_gray;
-    padding: 30px 0;
+    padding: 25px 0 35px;
 
-    h3 {
-      margin-bottom: 0.5em;
+    h4 {
+      margin: 0.25em 0;
     }
     p {
       .font-regular;
@@ -113,6 +116,26 @@ Contains styles for Comment confirmation success/fail/invalid pages.
     li {
       list-style-type: disc;
       margin: 0 0 5px 5px;
+    }
+  }
+
+  .tracking-number {
+    .fa {
+      display: inline-block;
+      margin: 4px 6px 0 0;
+      vertical-align: top;
+    }
+    .status {
+      background-color: @blue_light;
+      padding: 8px 16px;
+      margin: 16px 0;
+
+      .status-message {
+        display: inline-block;
+      }
+    }
+    .tracking-number-retrieved {
+      background-color: @green_light;
     }
   }
 

--- a/regulations/static/regulations/js/source/views/comment/comment-confirm-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-confirm-view.js
@@ -61,6 +61,7 @@ var CommentConfirmView = Backbone.View.extend({
 
   setTrackingNumber: function(number) {
     this.replaceTemplate('.tracking-number .status', {number: number});
+    this.addClass ('tracking-number-retrieved');
   }
 });
 

--- a/regulations/static/regulations/js/source/views/comment/comment-confirm-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-confirm-view.js
@@ -61,7 +61,7 @@ var CommentConfirmView = Backbone.View.extend({
 
   setTrackingNumber: function(number) {
     this.replaceTemplate('.tracking-number .status', {number: number});
-    this.addClass ('tracking-number-retrieved');
+    $('.status').addClass('tracking-number-retrieved');
   }
 });
 

--- a/regulations/static/regulations/js/source/views/comment/comment-confirm-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-confirm-view.js
@@ -59,9 +59,11 @@ var CommentConfirmView = Backbone.View.extend({
     this.replaceTemplate('.save-pdf', {url: url});
   },
 
+// Changes text and color of background when tracking number is received, hides wait message
   setTrackingNumber: function(number) {
     this.replaceTemplate('.tracking-number .status', {number: number});
     $('.status').addClass('tracking-number-retrieved');
+    $('.status-waiting').hide();
   }
 });
 

--- a/regulations/static/regulations/js/source/views/comment/comment-confirm-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-confirm-view.js
@@ -62,8 +62,8 @@ var CommentConfirmView = Backbone.View.extend({
 // Changes text and color of background when tracking number is received, hides wait message
   setTrackingNumber: function(number) {
     this.replaceTemplate('.tracking-number .status', {number: number});
-    $('.status').addClass('tracking-number-retrieved');
-    $('.status-waiting').hide();
+    this.$el.find('.status').addClass('tracking-number-retrieved');
+    this.$el.find('.status-waiting').hide();
   }
 });
 

--- a/regulations/templates/regulations/comment-confirm-fail.html
+++ b/regulations/templates/regulations/comment-confirm-fail.html
@@ -4,21 +4,21 @@
   <div class="comment-confirm-alert fail-alert">
     <div class="fa fa-2x fa-exclamation-circle"></div>
     <div class="alert-text">
-      <h2>Comment submission failed.</h2>
+      <h3>Comment submission failed.</h3>
       <p>We're sorry, something went wrong with our system, and submitting your comment did not work.</p>
     </div>
   </div>
 
   <div class="return-to-draft">
-    <h3>
+    <h4>
       <a href="{% url 'comment_review' doc_number %}">
         <span class="fa fa-chevron-left"></span>
         Return to your draft comment</a> to try submitting again.
-    </h3>
+    </h4>
   </div>
 
   <section class="problem-persist">
-    <h3>If this problem keeps happening</h3>
+    <h4>If this problem keeps happening</h4>
     <p>
       If you've already tried submitting your comment more than once, please save a copy of your draft comment for safekeeping.
     </p>

--- a/regulations/templates/regulations/comment-confirm-invalid.html
+++ b/regulations/templates/regulations/comment-confirm-invalid.html
@@ -4,21 +4,21 @@
   <div class="comment-confirm-alert fail-alert">
     <div class="fa fa-2x fa-exclamation-circle"></div>
     <div class="alert-text">
-      <h2>Comment submission invalid.</h2>
+      <h3>Comment submission invalid.</h3>
       <p>Your submission was invalid: {{ message }}</p>
     </div>
   </div>
 
   <div class="return-to-draft">
-    <h3>
+    <h4>
       <a href="{% url 'comment_review' doc_number %}">
         <span class="fa fa-chevron-left"></span>
         Return to your draft comment</a> to try submitting again.
-    </h3>
+    </h4>
   </div>
 
   <section class="problem-persist">
-    <h3>If this problem keeps happening</h3>
+    <h4>If this problem keeps happening</h4>
     <p>
       If you've already tried submitting your comment more than once, please save a copy of your draft comment for safekeeping.
     </p>

--- a/regulations/templates/regulations/comment-confirm-success.html
+++ b/regulations/templates/regulations/comment-confirm-success.html
@@ -29,9 +29,8 @@
       <div class="status-message">
         <strong>Waiting to receive comment tracking number. This may take a few seconds or minutes.</strong>
         <script class="js-template" type="text/template">
-          <div class="tracking-number-retrieved">
-            <span class="fa fa-check-circle" aria-hidden="true"></span>
-            Comment tracking number: <strong><%= number %></strong></div>
+          <span class="fa fa-check-circle" aria-hidden="true"></span>
+          Comment tracking number: <strong><%= number %></strong>
         </script>
       </div>
     </div>

--- a/regulations/templates/regulations/comment-confirm-success.html
+++ b/regulations/templates/regulations/comment-confirm-success.html
@@ -4,7 +4,7 @@
   <div class="comment-confirm-alert success-alert">
     <div class="fa fa-2x fa-check-circle"></div>
     <div class="alert-text">
-      <h2>Success!</h2>
+      <h3>Success!</h3>
       <p>Thank you for submitting your comment to EPA. You're done!</p>
     </div>
   </div>
@@ -18,26 +18,31 @@
     </script>
   </div>
   <section class="tracking-number">
-    <h3>Your comment tracking number</h3>
+    <h4>Your comment tracking number</h4>
     <p>
       The first step EPA takes is to assign your comment a tracking number.
       This page automatically displays that number when received:
     </p>
-    <p class="status">
-      Waiting to receive comment tracking number. This may take a few seconds
-      or minutes.
-      <script class="js-template" type="text/template">
-        <div>Comment tracking number: <%= number %></div>
-      </script>
-    </p>
+    <div class="status">
+      <div class="fa fa-spinner fa-pulse fa-1x fa-fw"></div>
+      <span class="sr-only">Loading...</span>
+      <div class="status-message">
+        <strong>Waiting to receive comment tracking number. This may take a few seconds or minutes.</strong>
+        <script class="js-template" type="text/template">
+          <div class="tracking-number-retrieved">
+            <span class="fa fa-check-circle" aria-hidden="true"></span>
+            Comment tracking number: <strong><%= number %></strong></div>
+        </script>
+      </div>
+    </div>
     <p>
       Your comment tracking number can help you find and view your public comment later if you want to.
     </p>
   </section>
   <section class="what-will-happen">
 
-    <h3>What will happen to your comment</h3>
-    <h4>EPA will process it and in most cases will post it publicly</h4>
+    <h4>What will happen to your comment</h4>
+    <h5>EPA will process it and in most cases will post it publicly</h5>
     <ul>
       <li>
         EPA will process your comment, which may take a few days or weeks depending
@@ -56,7 +61,7 @@
       </li>
     </ul>
 
-    <h4>EPA will review eligible comments and will usually publish a final rule</h4>
+    <h5>EPA will review eligible comments and will usually publish a final rule</h5>
     <ul>
       <li>
         After this comment period ends, EPA will review the comments, and usually
@@ -76,7 +81,7 @@
 
   <section class="feedback">
 
-    <h3>You can give feedback on this tool</h3>
+    <h4>You can give feedback on this tool</h4>
     <div>
       This eRegulations commenting tool was developed by <a href="https://18f.gsa.gov/" target="_blank">18F <span class="cf-icon cf-icon-external-link"></span></a>
       (part of the <a href="http://www.gsa.gov/" target="_blank">General Services Administration <span class="cf-icon cf-icon-external-link"></span></a>)

--- a/regulations/templates/regulations/comment-confirm-success.html
+++ b/regulations/templates/regulations/comment-confirm-success.html
@@ -23,15 +23,23 @@
       The first step EPA takes is to assign your comment a tracking number.
       This page automatically displays that number when received:
     </p>
-    <div class="status">
-      <div class="fa fa-spinner fa-pulse fa-1x fa-fw"></div>
-      <span class="sr-only">Loading...</span>
-      <div class="status-message">
-        <strong>Waiting to receive comment tracking number. This may take a few seconds or minutes.</strong>
-        <script class="js-template" type="text/template">
-          <span class="fa fa-check-circle" aria-hidden="true"></span>
-          Comment tracking number: <strong><%= number %></strong>
-        </script>
+    <div class="status-container">
+      <div class="status">
+        <div class="fa fa-spinner fa-pulse fa-1x fa-fw"></div>
+        <span class="sr-only">Loading...</span>
+        <div class="status-message">
+          <strong>Waiting to receive comment tracking number. This may take a few seconds or minutes.</strong>
+          <script class="js-template" type="text/template">
+            <span class="fa fa-check-circle" aria-hidden="true"></span>
+            Comment tracking number: <strong><%= number %></strong>
+          </script>
+        </div>
+      </div>
+      <div class="status-waiting">
+        <div class="fa fa-info-circle fa-fw"></div>
+        <div class="waiting-message">
+          If this is taking a long time, you don't have to wait for this, because you can also look up your comment later with keyword searches.
+        </div>
       </div>
     </div>
     <p>


### PR DESCRIPTION
Resolves many of the things in eregs/notice-and-comment#342.

Still investigating what it takes to make the "if this is taking long to load" thing that would appear after 10 seconds of not having a tracking number but wanted to give people a chance to look at this now. 