### PR TITLE
Add template for repeated submission failure

### DIFF
--- a/regulations/static/regulations/js/source/views/comment/comment-confirm-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-confirm-view.js
@@ -73,7 +73,7 @@ var CommentConfirmView = Backbone.View.extend({
 
   setRegsGovError: function() {
     this.replaceTemplate('.status-container', {}, '.js-regsgov-error');
-  },
+  }
 });
 
 module.exports = CommentConfirmView;

--- a/regulations/static/regulations/js/source/views/comment/comment-confirm-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-confirm-view.js
@@ -29,11 +29,13 @@ var CommentConfirmView = Backbone.View.extend({
     this.interval = window.setInterval(
       function() {
         $.getJSON(url).then(function(resp) {
-          if (resp.trackingNumber) {
+          if (resp.error) {
+            this.setRegsGovError();
+          } else {
             this.setPdfUrl(resp.pdfUrl);
             this.setTrackingNumber(resp.trackingNumber);
-            window.clearInterval(this.interval);
           }
+          window.clearInterval(this.interval);
         }.bind(this));
       }.bind(this),
       5000
@@ -44,10 +46,13 @@ var CommentConfirmView = Backbone.View.extend({
    * Fill in an element's (indicated by the selector) template with the ctx
    * provided
    **/
-  replaceTemplate: function(selector, ctx) {
+  replaceTemplate: function(selector, ctx, tplSelector) {
+    if (!tplSelector) {
+      tplSelector = '.js-template';
+    }
     this.$el.find(selector).each(function(idx, elt) {
       var $elt = $(elt);
-      var $tplElt = $elt.find('.js-template');
+      var $tplElt = $elt.find(tplSelector);
       var result = _.template($tplElt.prop('innerHTML'))(ctx);
       $elt.empty();
       $elt.append($tplElt);
@@ -59,12 +64,16 @@ var CommentConfirmView = Backbone.View.extend({
     this.replaceTemplate('.save-pdf', {url: url});
   },
 
-// Changes text and color of background when tracking number is received, hides wait message
+  // Changes text and color of background when tracking number is received, hides wait message
   setTrackingNumber: function(number) {
     this.replaceTemplate('.tracking-number .status', {number: number});
     this.$el.find('.status').addClass('tracking-number-retrieved');
     this.$el.find('.status-waiting').hide();
-  }
+  },
+
+  setRegsGovError: function() {
+    this.replaceTemplate('.status-container', {}, '.js-regsgov-error');
+  },
 });
 
 module.exports = CommentConfirmView;

--- a/regulations/tasks.py
+++ b/regulations/tasks.py
@@ -41,6 +41,10 @@ def submit_comment(self, comments, form_data, metadata_url):
     :param comments: List of sectional comments
     :param form_data: Dict of fields accepted by regulations.gov
     :param metadata_url: SignedUrl for comment metadata
+
+    :return: On success: {"trackingNumber": "...", "pdfUrl": "..."}
+             On failure: raises "retry" exception
+             On multiple failures: {"error": True}
     '''
     try:
         html = json_to_html(comments)
@@ -76,10 +80,7 @@ def submit_comment(self, comments, form_data, metadata_url):
         save_failed_submission(
             json.dumps({'comments': comments, 'form_data': form_data})
         )
-        return {
-            'pdfUrl': pdf_url.url,
-            'trackingNumber': None,
-        }
+        return {'error': True}
 
 
 @shared_task

--- a/regulations/tasks.py
+++ b/regulations/tasks.py
@@ -44,7 +44,7 @@ def submit_comment(self, comments, form_data, metadata_url):
 
     :return: On success: {"trackingNumber": "...", "pdfUrl": "..."}
              On failure: raises "retry" exception
-             On multiple failures: {"error": True}
+             On multiple failures: {"error": "Message"}
     '''
     try:
         html = json_to_html(comments)
@@ -80,11 +80,14 @@ def submit_comment(self, comments, form_data, metadata_url):
         save_failed_submission(
             json.dumps({'comments': comments, 'form_data': form_data})
         )
-        return {'error': True}
+        return {'error': message}
 
 
 @shared_task
 def publish_tracking_number(response, metadata_url):
+    """Write the tracking number to S3. Not ideal if this fails, but the
+    comment will have been taken care of already, so no need for additional
+    safety checks"""
     s3_client.put_object(
         Body=json.dumps(response).encode(),
         Bucket=settings.ATTACHMENT_BUCKET,

--- a/regulations/templates/regulations/comment-confirm-success.html
+++ b/regulations/templates/regulations/comment-confirm-success.html
@@ -41,6 +41,26 @@
           If this is taking a long time, you don't have to wait for this, because you can also look up your comment later with keyword searches.
         </div>
       </div>
+      <script class="js-regsgov-error" type="text/template">
+        <div class="status">
+          <div class="status-message">
+            <strong>
+              <span class="fa fa-exclamation-triangle"></span>
+              Sorry, we were not able to send your comment to the EPA docket at this
+              time.
+            </strong>
+          </div>
+        </div>
+        <div class="status-waiting">
+          <div class="fa fa-info-circle fa-fw"></div>
+          <div class="waiting-message">
+            This does not affect your comment! We will send your comment to the
+            EPA, and they will process it (their system may be busy at the
+            moment). You will be able to find your comment using keyword
+            searches after they process it, usually a few days.
+          </div>
+        </div>
+      </script>
     </div>
     <p>
       Your comment tracking number can help you find and view your public comment later if you want to.


### PR DESCRIPTION
If we try to submit to regs.gov multiple times, we eventually give up. The
worker process will notify the user by way of S3 that such an event has
occurred.

Adds a third parameter to the template replacement code if we want to target a
specific template (useful when there are nested divs).

Looks like:
<img width="700" alt="screen shot 2016-06-08 at 4 06 30 pm" src="https://cloud.githubusercontent.com/assets/326918/15909491/9bd87cba-2d94-11e6-97da-13dec9086346.png">


If you want to test locally, you'll want to:
```patch
diff --git a/regulations/tasks.py b/regulations/tasks.py
index f2b3499..4771b25 100644
--- a/regulations/tasks.py
+++ b/regulations/tasks.py
@@ -47,6 +47,7 @@ def submit_comment(self, comments, form_data, metadata_url):
              On multiple failures: {"error": True}
     '''
     try:
+        raise MaxRetriesExceededError()
         html = json_to_html(comments)
         files = extract_files(comments)
         try:
```

and restart your worker.

Resolves eregs/notice-and-comment#214