### PR TITLE
Don't explode when regs.gov is down

### DIFF
--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -465,7 +465,7 @@ class PrepareCommentView(View):
         context.update(generate_html_tree(context['preamble'], request,
                                           id_prefix=[doc_number, 'preamble']))
         context['comment_mode'] = 'write'
-        context['comment_fields'] = docket.get_document_fields(
+        context['comment_fields'] = docket.safe_get_document_fields(
             settings.COMMENT_DOCUMENT_ID)
         template = 'regulations/comment-review-chrome.html'
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,6 +3,7 @@ coveralls
 django-nose
 pep8==1.5.7
 flake8
+httpretty
 mock
 nose-exclude
 nose-testconfig


### PR DESCRIPTION
We still want to accept users comments in this scenario, we'll just expect the
ultimate submission to be manual.

Resolves eregs/notice-and-comment#343