### PR TITLE
Mobile Style Polish

### DIFF
--- a/regulations/static/regulations/css/less/module/comment-media-queries.less
+++ b/regulations/static/regulations/css/less/module/comment-media-queries.less
@@ -276,9 +276,44 @@ comment-media-queries.less contains media query styles for Notice and Comment
     padding-left: 0;
     width: 100%;
 
-    .comment h2 {
-      font-size: 30px;
-      margin-top: 0;
+    .comment-wrapper {
+      padding-left: 0;
+
+      .comment {
+        padding-bottom: 0;
+      }
+
+      .status {
+        text-align: left;
+      }
+    }
+
+    .comment-header-write,
+    .comment-context-wrapper {
+      display: none;
+    }
+
+    .comment-controls {
+      float: none;
+      padding-bottom: 0;
+      width: 100%;
+    }
+
+    .comment-upload-button {
+      width: 100%;
+    }
+
+    .comment-attachments-wrapper {
+      width: 100%;
+    }
+
+    .comment-submission {
+      width: 100%;
+      float: none;
+    }
+
+    .comment-button {
+      float: none;
     }
 
     .comment-index {
@@ -292,31 +327,9 @@ comment-media-queries.less contains media query styles for Notice and Comment
       }
     }
 
-    .comment-controls {
-      float: none;
-      margin-bottom: 10px;
-      width: 100%;
-
-      button, div {
-        float: none;
-      }
-    }
-
-    .comment-submission {
-      width: 100%;
-      float: none;
-    }
-
-    .comment-button {
-      float: none;
-    }
-
-    .comment-wrapper .status {
-      text-align: left;
-    }
-
     a.comment-index-review {
-      float: left;
+      text-align: center;
+      width: 100%;
     }
   }
 
@@ -348,6 +361,7 @@ comment-media-queries.less contains media query styles for Notice and Comment
       }
     }
   }
+
   .section-nav .previous {
     margin-left: -10px;
   }

--- a/regulations/static/regulations/css/less/module/comment-media-queries.less
+++ b/regulations/static/regulations/css/less/module/comment-media-queries.less
@@ -103,6 +103,10 @@ comment-media-queries.less contains media query styles for Notice and Comment
       top: 0;
       width: 100%;
 
+      a {
+        color: @pacific_hover;
+      }
+
       &:hover {
         color: #4A90E2;
       }
@@ -247,10 +251,6 @@ comment-media-queries.less contains media query styles for Notice and Comment
       .activate-write {
         display: none;
       }
-    }
-
-    .activate-write a {
-      color: @pacific_hover;
     }
 
     .show-more-context {

--- a/regulations/static/regulations/css/less/module/comment-media-queries.less
+++ b/regulations/static/regulations/css/less/module/comment-media-queries.less
@@ -142,6 +142,10 @@ comment-media-queries.less contains media query styles for Notice and Comment
     .toc-head {
       z-index: 100;
     }
+
+    #content-header {
+      padding-left: 15px;
+    }
   }
 
   .preamble-header {
@@ -161,7 +165,6 @@ comment-media-queries.less contains media query styles for Notice and Comment
     .write-comment {
       border-bottom: 1px solid @medium_gray;
       border-top: 1px solid @medium_gray;
-      font-size: 13px;
       width: 50% !important;
     }
 
@@ -171,15 +174,34 @@ comment-media-queries.less contains media query styles for Notice and Comment
   }
 
   .preamble-wrapper {
-    padding-top: 85px;
-  }
+    padding-left: 55px;
+    padding-top: 35px;
 
-  h3.section-title {
-    font-size: 30px;
+    h3 {
+      font-size: 24px;
+      line-height: 30px;
+    }
+    h4 {
+      font-size: 19px;
+      line-height: 24px;
+
+      &.small-header {
+        font-size: 14px;
+        line-height: 20px;
+      }
+    }
   }
 
   #preamble-read {
     padding-left: 0;
+
+    .comment-period-dates {
+      margin-top: 20px;
+    }
+
+    .days-remaining {
+      display: none;
+    }
 
     ol, ul {
       padding-left: 0;
@@ -196,6 +218,12 @@ comment-media-queries.less contains media query styles for Notice and Comment
 
     .node {
       padding-right: 0;
+    }
+
+    .not-called-out {
+      .activate-write {
+        display: none;
+      }
     }
 
     .show-more-context {

--- a/regulations/static/regulations/css/less/module/comment-media-queries.less
+++ b/regulations/static/regulations/css/less/module/comment-media-queries.less
@@ -61,9 +61,25 @@ comment-media-queries.less contains media query styles for Notice and Comment
 // tablet + mobile screen sizes
 @media only screen and ( max-width: 780px ) {
 
+  .preamble-sub-head {
+
+    #content-header {
+      padding-left: 35px;
+    }
+  }
+
   .hide-mobile {
     display: none;
     padding: 0;
+  }
+
+  .preamble-header {
+
+    .read-proposal,
+    .write-comment {
+      padding: 0 15px;
+      width: auto !important;
+    }
   }
 
   #preamble-read {
@@ -81,7 +97,7 @@ comment-media-queries.less contains media query styles for Notice and Comment
     }
 
     .activate-write {
-      padding: 5px 0;
+      padding: 0 0 5px;
       position: relative;
       right: 0;
       top: 0;
@@ -106,7 +122,6 @@ comment-media-queries.less contains media query styles for Notice and Comment
     .comment-index {
       right: -220px;
       width: 210px;
-
 
       li {
         .comment-index-section {

--- a/regulations/static/regulations/css/less/module/comment-media-queries.less
+++ b/regulations/static/regulations/css/less/module/comment-media-queries.less
@@ -134,6 +134,14 @@ comment-media-queries.less contains media query styles for Notice and Comment
       }
     }
   }
+
+  .next-prev {
+    .border-top-medium (@width: 2px);
+  }
+
+  .next-prev-label {
+    display: inline-block;
+  }
 }
 
 // mobile screen size
@@ -190,7 +198,7 @@ comment-media-queries.less contains media query styles for Notice and Comment
 
   .preamble-wrapper {
     padding-left: 55px;
-    padding-top: 35px;
+    padding-top: 40px;
 
     h3 {
       font-size: 24px;
@@ -239,6 +247,10 @@ comment-media-queries.less contains media query styles for Notice and Comment
       .activate-write {
         display: none;
       }
+    }
+
+    .activate-write a {
+      color: @pacific_hover;
     }
 
     .show-more-context {

--- a/regulations/static/regulations/css/less/module/header.less
+++ b/regulations/static/regulations/css/less/module/header.less
@@ -315,7 +315,7 @@ tiny screens
         height: 57px;
         position: absolute;
         right: 0;
-        padding: 19px 15px 0 15px;
+        padding: 14px 15px 0 15px;
     }
 
     .mobile-nav-trigger:hover,

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -58,7 +58,7 @@
       {% elif meta.comment_state.name == 'OPEN' %}
         <div class="comment-wrapper">
           <div class="comment">
-            <h4 class="comment-header">
+            <h4 class="comment-header comment-header-write">
               You are writing about
               <span class="comment-header-link"></span>
             </h4>
@@ -89,7 +89,7 @@
 
             </div>
 
-            <h4 class="comment-header">
+            <h4 class="comment-header comment-header-response">
               Write your response to
               <span class="comment-header-link"></span>
             </h4>

--- a/regulations/templates/regulations/tree/preamble_intro.html
+++ b/regulations/templates/regulations/tree/preamble_intro.html
@@ -9,19 +9,6 @@
     id="{{node.markup_id}}"
     data-permalink-section>
   <div class="node">
-    {% if meta.comment_state.name == 'OPEN' and node.accepts_comments %}
-      <div
-          class="activate-write"
-          data-section="{{ node.full_id }}"
-          data-label="{{ node.human_label }}">
-        <a href="#">
-          <div class="paragraph-comment-icon">
-            <span class="fa fa-pencil-square-o" aria-hidden="true"></span>
-          </div>
-          <div class="paragraph-comment">Write a comment about {{ node.human_label }}</div>
-        </a>
-      </div>
-    {% endif %}
     <h4 class="small-header">{{ meta.primary_agency }}</h4>
     <h3>{{ meta.title }}</h3>
     <div class="comment-period-dates">
@@ -63,6 +50,19 @@
       {{meta.dockets|join:"; "}}<br />
       {{meta.regulation_id_numbers|join:"; "}}
     </p>
+    {% if meta.comment_state.name == 'OPEN' and node.accepts_comments %}
+      <div
+          class="activate-write"
+          data-section="{{ node.full_id }}"
+          data-label="{{ node.human_label }}">
+        <a href="#">
+          <div class="paragraph-comment-icon">
+            <span class="fa fa-pencil-square-o" aria-hidden="true"></span>
+          </div>
+          <div class="paragraph-comment">Write a comment about {{ node.human_label }}</div>
+        </a>
+      </div>
+    {% endif %}
   </div>
 </li>
 {% for c in node.children %}


### PR DESCRIPTION
For eregs/notice-and-comment#356

General
- set top padding to 30px between header and content
- type hierarchies
- header mobile menu (hamburger) vertically aligned - this affects general eregs

Intro
- Hide days remaining

Tabs and Drawer
- Read/Write tab font size
- Set 15px Read/Write tab spacing in tablet

Read Mode
- Hide "write a comment" hover links
- "Write a comment" links darker blue
- Footer says previous/next and has top border

Write Mode
- Hide excerpt
- Tighten spacing in comment upload attachment and save buttons, and made them full width for visibility

<img width="318" alt="screen shot 2016-06-08 at 10 02 34 pm" src="https://cloud.githubusercontent.com/assets/24054/15919351/6d3160e4-2dc5-11e6-9b46-4d6a0db18b4f.png">
<img width="321" alt="screen shot 2016-06-08 at 10 00 30 pm" src="https://cloud.githubusercontent.com/assets/24054/15919352/6ffc59dc-2dc5-11e6-8ff5-2b7e8027c469.png">
<img width="322" alt="screen shot 2016-06-08 at 10 00 54 pm" src="https://cloud.githubusercontent.com/assets/24054/15919354/72a6f584-2dc5-11e6-9b97-b1ddf29a2387.png">
<img width="320" alt="screen shot 2016-06-08 at 10 08 35 pm" src="https://cloud.githubusercontent.com/assets/24054/15919362/84edb106-2dc5-11e6-84a0-f8bc7b6f5528.png">
<img width="320" alt="screen shot 2016-06-08 at 10 01 10 pm" src="https://cloud.githubusercontent.com/assets/24054/15919363/87ebe27e-2dc5-11e6-950f-a34e938d0599.png">
<img width="321" alt="screen shot 2016-06-08 at 10 01 32 pm" src="https://cloud.githubusercontent.com/assets/24054/15919364/89c100b6-2dc5-11e6-92f2-ae04a093a653.png">

