### PR TITLE
Rework error handling

### DIFF
--- a/regulations/tasks.py
+++ b/regulations/tasks.py
@@ -74,6 +74,7 @@ def submit_comment(self, comments, form_data, metadata_url):
             raise self.retry()
         except MaxRetriesExceededError:
             message = "Exceeded retries, saving failed submission"
+            logger.error(message)
             save_failed_submission(
                 json.dumps({'comments': comments, 'form_data': form_data})
             )


### PR DESCRIPTION
As comment data is precious, we want to store to retry on _any_ error, and
store to the database if there have been too many attempts.

We should probably raise the exception so that it fails loudly, but the
results are currently chained in a way that'd make that more difficult.

This also sets acks_late on the shared_tasks (rather than using a global
setting) due to the importance of the task. Acks_late will allow a task to be
taken when the original worker process dies (not due to an exception, but
some abrupt failure outside of our process).

For eregs/notice-and-comment#286