### PR TITLE
Accessibility Updates

### DIFF
--- a/regulations/static/regulations/css/less/module/comment-review.less
+++ b/regulations/static/regulations/css/less/module/comment-review.less
@@ -188,6 +188,10 @@ comment-review.less contains styles for Review Your Comment page
       }
     }
 
+    .gov_agency_federal_select_label {
+      display: none;
+    }
+
     .select-dropdown {
       position: relative;
 
@@ -266,7 +270,7 @@ comment-review.less contains styles for Review Your Comment page
       margin: 0.5em 0;
     }
 
-    h6 {
+    h5 {
       .font-regular;
       font-size: 16px;
       text-transform: none;

--- a/regulations/static/regulations/css/less/module/comment-review.less
+++ b/regulations/static/regulations/css/less/module/comment-review.less
@@ -4,7 +4,7 @@ comment-review.less
 comment-review.less contains styles for Review Your Comment page
 */
 
-#comment-review {
+.comment-review {
   .font-regular;
   margin-bottom: 50px;
   padding-left: 25px;

--- a/regulations/static/regulations/css/less/module/comment-review.less
+++ b/regulations/static/regulations/css/less/module/comment-review.less
@@ -232,9 +232,7 @@ comment-review.less contains styles for Review Your Comment page
     }
 
     legend {
-      font-size: 17px;
-      font-weight: bold;
-      line-height: 17px;
+      display: none;
     }
 
     input[type=text] {

--- a/regulations/static/regulations/css/less/module/comment-review.less
+++ b/regulations/static/regulations/css/less/module/comment-review.less
@@ -188,10 +188,6 @@ comment-review.less contains styles for Review Your Comment page
       }
     }
 
-    .gov_agency_federal_select_label {
-      display: none;
-    }
-
     .select-dropdown {
       position: relative;
 

--- a/regulations/static/regulations/css/less/module/drawer-content.less
+++ b/regulations/static/regulations/css/less/module/drawer-content.less
@@ -230,18 +230,20 @@ This contains all of the styles specific to the history
         display: block;
     }
 
-    h4 {
+    h2 {
         .reset;
         font-size: 0.875em;
         text-transform: uppercase;
         color: @dark_text;
+        line-height: normal;
     }
 
-    h5 {
+    h3 {
         .reset;
         font-size: 0.875em;
         text-transform: uppercase;
         color: @dark_text;
+        line-height: normal;
     }
 
     .final-rule {
@@ -387,9 +389,11 @@ This contains all of the styles specific to the search
         padding-top: 40px;
     }
 
-    h4 {
+    h3 {
         color: @dark_text;
         .font-regular;
+        font-size: 0.875em;
+        line-height: normal;
         text-transform: none;
         margin-bottom: 0.5em;
     }

--- a/regulations/static/regulations/css/less/module/drawer.less
+++ b/regulations/static/regulations/css/less/module/drawer.less
@@ -79,13 +79,13 @@ Panel Header
     height: 22px;
   }
 
-  h3 {
+  h2 {
     color: @black;
     font-size: 0.875em;
     text-transform: uppercase;
   }
 
-  h4 {
+  h3 {
     color: @black;
     .font-regular;
     font-size: 0.875em;

--- a/regulations/static/regulations/css/less/module/drawer.less
+++ b/regulations/static/regulations/css/less/module/drawer.less
@@ -83,6 +83,7 @@ Panel Header
     color: @black;
     font-size: 0.875em;
     text-transform: uppercase;
+    font-weight: bold;
   }
 
   h3 {

--- a/regulations/static/regulations/css/less/module/drawer.less
+++ b/regulations/static/regulations/css/less/module/drawer.less
@@ -85,7 +85,7 @@ Panel Header
     text-transform: uppercase;
   }
 
-  h5 {
+  h4 {
     color: @black;
     .font-regular;
     font-size: 0.875em;

--- a/regulations/templates/regulations/chrome.html
+++ b/regulations/templates/regulations/chrome.html
@@ -89,7 +89,7 @@
     {% block drawer-history %}
         <div id="timeline" class="history-drawer toc-container hidden">
             <div class="drawer-header">
-                <h3 class="toc-type">Regulation Timeline</h3>
+                <h2 class="toc-type">Regulation Timeline</h2>
             </div><!-- /.drawer-header -->
             <div class="drawer-content">
                 <p class="effective-label">Find the regulation effective on this date:</p>
@@ -152,7 +152,7 @@
     {% block drawer-search %}
     <div id="search" class="search-drawer toc-container hidden">
         <div class="drawer-header">
-            <h3 class="toc-type">Search</h3>
+            <h2 class="toc-type">Search</h2>
         </div><!-- /.drawer-header -->
         <div class="drawer-content">
             <form action="{% url 'chrome_search' reg_part %}" method="GET" role="search" data-doc-type="cfr">

--- a/regulations/templates/regulations/chrome.html
+++ b/regulations/templates/regulations/chrome.html
@@ -108,7 +108,7 @@
                     <li class="{% if version.version == active_version %}current {% endif %}status-list" data-base-version="{{version.version}}">
                     <a href="{% url version_switch_view label_id version.version %}" class="version-link" data-version="{{ version.version }}" id="link-{{ version.version }}">
                         {% if version.timeline == 'current' %}
-                            <h4>Current Law</h4>
+                            <h3>Current Law</h3>
                         {% endif %}
                         <span class="version-date">{{ version.by_date|date }}</span>
                     </a>
@@ -126,7 +126,7 @@
                             {% endfor %}
                             </ul>
                             <div class="diff-selector group">
-                                <h4 class="compare-title">Compare {{reg_part}} effective on {{version.by_date|date}} with</h4>
+                                <h3 class="compare-title">Compare {{reg_part}} effective on {{version.by_date|date}} with</h3>
                                 <form action="{% url 'diff_redirect' diff_redirect_label active_version %}" method="GET">
                                   <div class="select-content">
                                     <select name="new_version" title="Compare version">
@@ -160,7 +160,7 @@
                     <input type="text" name="q" value="{{ q }}" id="search-input" title="Search term"/><button type="submit"><span class="cf-icon cf-icon-search"></span><strong class="icon-text">Search</strong></button>
                 </div><!--/.search-box-->
                 <div class="version-search">
-                    <h4>Search in regulation effective:</h4>
+                    <h3>Search in regulation effective:</h3>
                     <div class="select-content">
                         <select name="version" id="version-select" title="Effective version">
                         {% for version in history %}

--- a/regulations/templates/regulations/chrome.html
+++ b/regulations/templates/regulations/chrome.html
@@ -113,7 +113,7 @@
                         <span class="version-date">{{ version.by_date|date }}</span>
                     </a>
                         <div class="timeline-content-wrap">
-                            <h5 class="final-rule">Final Rule</h5>
+                            <h3 class="final-rule">Final Rule</h3>
                             <ul class="rule-list">
                             {% for notice in version.notices %}
                               {% with pub_date=notice.publication_date|date %}

--- a/regulations/templates/regulations/comment-review-chrome.html
+++ b/regulations/templates/regulations/comment-review-chrome.html
@@ -3,7 +3,7 @@
 {% block chrome-content %}
 <main role="main">
   <div id="content-body" class="main-content preamble-wrapper comment-review-wrapper">
-    <section id="comment-review" data-page-type="comment-review" data-doc-id="{{doc_number}}">
+    <section id="content-wrapper" class="comment-review" data-page-type="comment-review" data-doc-id="{{doc_number}}">
       <h3>Review your full comment</h3>
       <h4>You are submitting an official comment to Regulations.gov.</h4>
       <div class="comment-review-items"></div>

--- a/regulations/templates/regulations/diff-chrome.html
+++ b/regulations/templates/regulations/diff-chrome.html
@@ -72,7 +72,7 @@ Comparison of {{meta.cfr_title_number}} CFR {{formatted_id}} | eRegulations
                     {% endif %}-->
                     <a href="{% url 'chrome_section_view' label_id version.version %}" class="version-link" data-version="{{ version.version }}">
                         {% if version.timeline == 'current' %}
-                            <h4>Current Law</h4>
+                            <h3>Current Law</h3>
                         {% endif %}
                         <span class="version-date">{{ version.by_date|date }}</span>
                     </a>

--- a/regulations/templates/regulations/diff-chrome.html
+++ b/regulations/templates/regulations/diff-chrome.html
@@ -28,7 +28,7 @@ Comparison of {{meta.cfr_title_number}} CFR {{formatted_id}} | eRegulations
 {% block drawer-toc %}
 <div class="toc-drawer toc-container current hidden diff-toc" id="table-of-contents" data-from-version="{{from_version}}">
     <div class="drawer-header">
-        <h3 class="toc-type">Table of Contents</h3>
+        <h2 class="toc-type">Table of Contents</h2>
     </div><!-- /.drawer-header -->
     <nav id="toc" class="regulation-nav" role="navigation">
         <ol class="drawer-content">
@@ -49,7 +49,7 @@ Comparison of {{meta.cfr_title_number}} CFR {{formatted_id}} | eRegulations
 {% block drawer-history %}
     <div id="timeline" class="history-drawer toc-container hidden diff-history">
         <div class="drawer-header">
-            <h3 class="toc-type">Regulation versions</h3>
+            <h2 class="toc-type">Regulation versions</h2>
         </div><!-- /.drawer-header -->
         <div class="drawer-content">
             <p class="effective-label">Find the regulation effective on this date:</p>

--- a/regulations/templates/regulations/preamble-base.html
+++ b/regulations/templates/regulations/preamble-base.html
@@ -45,8 +45,8 @@
 
   <div id="table-of-contents-secondary" class="toc-container hidden">
     <div class="drawer-header">
-      <h3 class="toc-type">Table of Contents</h3>
-      <h4 class="toc-subheader">Amendments to the CFR</h4>
+      <h2 class="toc-type">Table of Contents</h2>
+      <h3 class="toc-subheader">Amendments to the CFR</h3>
     </div>
     <nav id="cfr-toc" class="regulation-nav drawer-content preamble-nav" role="navigation">
       <ol>
@@ -66,7 +66,7 @@
   {% block drawer-search %}
   <div id="search" class="search-drawer toc-container hidden">
       <div class="drawer-header">
-          <h3 class="toc-type">Search</h3>
+          <h2 class="toc-type">Search</h2>
       </div><!-- /.drawer-header -->
       <div class="drawer-content">
           <form method="GET" role="search" data-doc-type="preamble">

--- a/regulations/templates/regulations/preamble-base.html
+++ b/regulations/templates/regulations/preamble-base.html
@@ -35,8 +35,8 @@
 <div id="menu" class="panel" data-page-type="preamble-section" data-doc-id="{{doc_number}}">
   <div class="toc-drawer toc-container current hidden diff-toc" id="table-of-contents">
     <div class="drawer-header">
-      <h3 class="toc-type">Table of Contents</h3>
-      <h4 class="toc-subheader">Preamble</h4>
+      <h2 class="toc-type">Table of Contents</h2>
+      <h3 class="toc-subheader">Preamble</h3>
     </div><!-- /.drawer-header -->
     <nav id="toc" class="regulation-nav drawer-content preamble-nav" role="navigation">
       {% include "regulations/toc-preamble.html" %}

--- a/regulations/templates/regulations/preamble-base.html
+++ b/regulations/templates/regulations/preamble-base.html
@@ -36,7 +36,7 @@
   <div class="toc-drawer toc-container current hidden diff-toc" id="table-of-contents">
     <div class="drawer-header">
       <h3 class="toc-type">Table of Contents</h3>
-      <h5 class="toc-subheader">Preamble</h5>
+      <h4 class="toc-subheader">Preamble</h4>
     </div><!-- /.drawer-header -->
     <nav id="toc" class="regulation-nav drawer-content preamble-nav" role="navigation">
       {% include "regulations/toc-preamble.html" %}
@@ -46,7 +46,7 @@
   <div id="table-of-contents-secondary" class="toc-container hidden">
     <div class="drawer-header">
       <h3 class="toc-type">Table of Contents</h3>
-      <h5 class="toc-subheader">Amendments to the CFR</h5>
+      <h4 class="toc-subheader">Amendments to the CFR</h4>
     </div>
     <nav id="cfr-toc" class="regulation-nav drawer-content preamble-nav" role="navigation">
       <ol>

--- a/regulations/templates/regulations/preamble-chrome.html
+++ b/regulations/templates/regulations/preamble-chrome.html
@@ -6,7 +6,9 @@
 <main role="main">
 
   <div id="content-body" class="main-content preamble-wrapper">
-    {% include "regulations/preamble-partial.html" %}
+    <section id="content-wrapper">
+      {% include "regulations/preamble-partial.html" %}
+    </section>
   </div> <!-- /.main-content -->
 
 </main>

--- a/regulations/templates/regulations/preamble-chrome.html
+++ b/regulations/templates/regulations/preamble-chrome.html
@@ -6,9 +6,7 @@
 <main role="main">
 
   <div id="content-body" class="main-content preamble-wrapper">
-    <section id="content-wrapper">
-      {% include "regulations/preamble-partial.html" %}
-    </section>
+    {% include "regulations/preamble-partial.html" %}
   </div> <!-- /.main-content -->
 
 </main>

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -99,8 +99,8 @@
               <div class="comment-controls group">
                 <div class="comment-attachments-wrapper">
                   <div class="comment-attachments"></div>
-                  <label class="comment-upload-button file-upload">
-                    Upload Attachment<input type="file" multiple/>
+                  <label for="upload-attachment" class="comment-upload-button file-upload">
+                    Upload Attachment<input type="file" id="upload-attachment" multiple/>
                   </label>
                   <div class="comment-attachment-count"></div>
                   <div class="comment-attachment-limit"></div>

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -1,153 +1,152 @@
 {% load macros render_nested %}
 
-<section id="content-wrapper">
-  <section
-      id="{{full_id}}"
-      class="reg-section"
-      data-page-type="preamble-section"
-      data-doc-id="{{doc_number}}"
-      data-label="{{section_label}}">
-    <div id="preamble-read">
-      <div class="preamble-content">
-        {% if type == "preamble" %}
-        <ul>
-          {% render_nested template=sub_template context=sub_context %}
-        </ul>
-        {% else %}
-          {% render_nested template=sub_template context=sub_context %}
-        {% endif %}
-      </div>
-
-      {% include "regulations/footnotes.html" %}
-      {% include "regulations/navigation.html" %}
-    </div>
-
-    <div id="preamble-write">
-      {% if meta.comment_state.name == 'NO_COMMENT' %}
-        {% block no-comment-warning %}
-          <div class="comment-wrapper">
-            <div class="write-warning">
-              <div class="fa fa-3x fa-info-circle"></div>
-              <h3>This notice does not accept comments</h3>
-            </div>
-            <div>
-              <a href="{{request.path}}">
-                <span class="cf-icon cf-icon-left"></span>
-                <span class="back-to-proposal">Back to read the proposal</span>
-              </a>
-            </div>
-          </div>
-        {% endblock %}
-      {% elif meta.comment_state.name == 'PREPUB' %}
-        {% block prepub-warning %}
-          <div class="comment-wrapper">
-            <div class="write-warning">
-              <div class="fa fa-3x fa-info-circle"></div>
-              <h3>Comment period is not open</h3>
-              <p>The comment period will open once the rule is officially
-              published in the Federal Register</p>
-            </div>
-            <div>
-              <a href="{{request.path}}">
-                <span class="cf-icon cf-icon-left"></span>
-                <span class="back-to-proposal">Back to read the proposal</span>
-              </a>
-            </div>
-          </div>
-        {% endblock %}
-      {% elif meta.comment_state.name == 'OPEN' %}
-        <div class="comment-wrapper">
-          <div class="comment">
-            <h4 class="comment-header comment-header-write">
-              You are writing about
-              <span class="comment-header-link"></span>
-            </h4>
-
-            <div class="comment-context-wrapper">
-
-              <a class="comment-context-toggle" href="#">
-                <span class="comment-context-text">
-                  <span class="fa fa-plus-circle" aria-hidden="true"></span>
-                  <span class="fa fa-minus-circle" aria-hidden="true"></span>
-                  <span class="comment-context-text-show">Show:</span>
-                  <span class="comment-context-text-hide">Hide:</span>
-                </span>
-                <span class="comment-context-label">
-                  <span class="comment-context-type">
-                  {% if type == "cfr" %}
-                    {{ type|upper }}
-                  {% else %}
-                    {{ type|capfirst }}
-                  {% endif %}
-                  </span>
-                  &nbsp;|&nbsp;
-                  <span class="comment-context-section"></span>
-                </span>
-              </a>
-
-              <div class="comment-context"></div>
-
-            </div>
-
-            <h4 class="comment-header comment-header-response">
-              Write your response to
-              <span class="comment-header-link"></span>
-            </h4>
-
-            <form>
-              <div class="editor-container"></div>
-              <div class="comment-controls group">
-                <div class="comment-attachments-wrapper">
-                  <div class="comment-attachments"></div>
-                  <label for="upload-attachment" class="comment-upload-button file-upload">
-                    Upload Attachment<input type="file" id="upload-attachment" multiple/>
-                  </label>
-                  <div class="comment-attachment-count"></div>
-                  <div class="comment-attachment-limit"></div>
-                </div>
-                <button class="comment-button comment-submission" type="submit">Save Response</button>
-                <a class="comment-delete-response" data-section="" href="#">
-                  <span class="fa fa-trash" aria-hidden="true"></span>
-                  Delete response
-                </a>
-                <div class="status"></div>
-              </div>
-            </form>
-          </div>
-        </div>
-        <div class="comment-index">
-          <ul class="comment-index-items"></ul>
-          <a href="{% url 'comment_review' doc_number=doc_number %}" class="comment-index-review">Review and Submit</a>
-        </div>
-      {% elif meta.comment_state.name == 'CLOSED' %}
-        {% block closed-warning %}
-          <div class="comment-wrapper">
-            <div class="write-warning">
-              <div class="fa fa-3x fa-info-circle"></div>
-              <h3>Comment period closed</h3>
-              <p>As of <strong>{{meta.comments_close|date:"F j, Y"}} at
-              11:59pm EST</strong>, we are no longer accepting comments on
-              this rule.</p>
-            </div>
-            <div class="warning-explanation">
-              {% with url="https://www.regulations.gov/#!documentDetail;D="|add:meta.primary_docket %}
-              {% with text="Visit the docket ("|add:meta.primary_docket|add:")" %}
-                {% external_link url=url text=text %}
-              {% endwith %}{% endwith %}
-              to view all the public comments on this rule: {{meta.title}}.
-            </div>
-            <div>
-              <a href="{{request.path}}">
-                <span class="cf-icon cf-icon-left"></span>
-                <span class="back-to-proposal">Back to read the proposal</span>
-              </a>
-            </div>
-          </div>
-        {% endblock %}
+<section
+    id="{{full_id}}"
+    class="reg-section"
+    data-page-type="preamble-section"
+    data-doc-id="{{doc_number}}"
+    data-label="{{section_label}}">
+  <div id="preamble-read">
+    <div class="preamble-content">
+      {% if type == "preamble" %}
+      <ul>
+        {% render_nested template=sub_template context=sub_context %}
+      </ul>
+      {% else %}
+        {% render_nested template=sub_template context=sub_context %}
       {% endif %}
     </div>
-  </section>
+
+    {% include "regulations/footnotes.html" %}
+    {% include "regulations/navigation.html" %}
+  </div>
+
+  <div id="preamble-write">
+    {% if meta.comment_state.name == 'NO_COMMENT' %}
+      {% block no-comment-warning %}
+        <div class="comment-wrapper">
+          <div class="write-warning">
+            <div class="fa fa-3x fa-info-circle"></div>
+            <h3>This notice does not accept comments</h3>
+          </div>
+          <div>
+            <a href="{{request.path}}">
+              <span class="cf-icon cf-icon-left"></span>
+              <span class="back-to-proposal">Back to read the proposal</span>
+            </a>
+          </div>
+        </div>
+      {% endblock %}
+    {% elif meta.comment_state.name == 'PREPUB' %}
+      {% block prepub-warning %}
+        <div class="comment-wrapper">
+          <div class="write-warning">
+            <div class="fa fa-3x fa-info-circle"></div>
+            <h3>Comment period is not open</h3>
+            <p>The comment period will open once the rule is officially
+            published in the Federal Register</p>
+          </div>
+          <div>
+            <a href="{{request.path}}">
+              <span class="cf-icon cf-icon-left"></span>
+              <span class="back-to-proposal">Back to read the proposal</span>
+            </a>
+          </div>
+        </div>
+      {% endblock %}
+    {% elif meta.comment_state.name == 'OPEN' %}
+      <div class="comment-wrapper">
+        <div class="comment">
+          <h4 class="comment-header comment-header-write">
+            You are writing about
+            <span class="comment-header-link"></span>
+          </h4>
+
+          <div class="comment-context-wrapper">
+
+            <a class="comment-context-toggle" href="#">
+              <span class="comment-context-text">
+                <span class="fa fa-plus-circle" aria-hidden="true"></span>
+                <span class="fa fa-minus-circle" aria-hidden="true"></span>
+                <span class="comment-context-text-show">Show:</span>
+                <span class="comment-context-text-hide">Hide:</span>
+              </span>
+              <span class="comment-context-label">
+                <span class="comment-context-type">
+                {% if type == "cfr" %}
+                  {{ type|upper }}
+                {% else %}
+                  {{ type|capfirst }}
+                {% endif %}
+                </span>
+                &nbsp;|&nbsp;
+                <span class="comment-context-section"></span>
+              </span>
+            </a>
+
+            <div class="comment-context"></div>
+
+          </div>
+
+          <h4 class="comment-header comment-header-response">
+            Write your response to
+            <span class="comment-header-link"></span>
+          </h4>
+
+          <form>
+            <div class="editor-container"></div>
+            <div class="comment-controls group">
+              <div class="comment-attachments-wrapper">
+                <div class="comment-attachments"></div>
+                <label for="upload-attachment" class="comment-upload-button file-upload">
+                  Upload Attachment<input type="file" id="upload-attachment" multiple/>
+                </label>
+                <div class="comment-attachment-count"></div>
+                <div class="comment-attachment-limit"></div>
+              </div>
+              <button class="comment-button comment-submission" type="submit">Save Response</button>
+              <a class="comment-delete-response" data-section="" href="#">
+                <span class="fa fa-trash" aria-hidden="true"></span>
+                Delete response
+              </a>
+              <div class="status"></div>
+            </div>
+          </form>
+        </div>
+      </div>
+      <div class="comment-index">
+        <ul class="comment-index-items"></ul>
+        <a href="{% url 'comment_review' doc_number=doc_number %}" class="comment-index-review">Review and Submit</a>
+      </div>
+    {% elif meta.comment_state.name == 'CLOSED' %}
+      {% block closed-warning %}
+        <div class="comment-wrapper">
+          <div class="write-warning">
+            <div class="fa fa-3x fa-info-circle"></div>
+            <h3>Comment period closed</h3>
+            <p>As of <strong>{{meta.comments_close|date:"F j, Y"}} at
+            11:59pm EST</strong>, we are no longer accepting comments on
+            this rule.</p>
+          </div>
+          <div class="warning-explanation">
+            {% with url="https://www.regulations.gov/#!documentDetail;D="|add:meta.primary_docket %}
+            {% with text="Visit the docket ("|add:meta.primary_docket|add:")" %}
+              {% external_link url=url text=text %}
+            {% endwith %}{% endwith %}
+            to view all the public comments on this rule: {{meta.title}}.
+          </div>
+          <div>
+            <a href="{{request.path}}">
+              <span class="cf-icon cf-icon-left"></span>
+              <span class="back-to-proposal">Back to read the proposal</span>
+            </a>
+          </div>
+        </div>
+      {% endblock %}
+    {% endif %}
+  </div>
 </section>
+
 
 <script id="comment-attachment-template" type="text/template">
   <div class="comment-attachment">

--- a/regulations/templates/regulations/toc.html
+++ b/regulations/templates/regulations/toc.html
@@ -4,7 +4,7 @@
 <div {% if top_toc %}class="toc-drawer toc-container current hidden" id="table-of-contents"{% endif %}>
     {% if top_toc %}
         <div class="drawer-header">
-            <h3 class="toc-type">Table of Contents</h3>
+            <h2 class="toc-type">Table of Contents</h2>
         </div><!-- /.drawer-header -->
     {% endif %}
     <nav {% if top_toc %}id="toc" data-toc-version="{{ version }}" {% endif %}class="{{nav_class}} {% if top_toc %}drawer-content{% endif %}" role="navigation">


### PR DESCRIPTION
**General**
- Drawer header ordering
- Remove duplicate `#content-wrapper` section

**Write Mode**
- label `for` on upload attachment id

**Review page**
- add `#content-wrapper` id on review page for skip nav
- Hide label for federal agency name select
- Set correct order on statement headings

--
_Some of the remaining errors/warnings left from HTML_Codesniffer/Chrome Dev Accessibility Tool Audit are due to:_
- duplicate IDs
 - because of the cloning of data from read mode to write mode
- color contrast ratios
- anchor links not pointing within the document 
 - links to sections like `href="#0000_0000-I"` that are ajax links)
- non-focusable/obscured elements
 - most all of the content is tabbable, but certain elements like TOC or edit/delete index icons are accessible, but hidden until focused on.
- errors around datatables
 - missing `<caption>` 
 - unsupported aria attributes/roles

I consider those non-critical issues but they should definitely be addressed at a future maintenance point.

--

More changes at: eregs/notice-and-comment#376
