### PR TITLE
Review Download PDF error state

### DIFF
--- a/regulations/static/regulations/css/less/module/comment-review.less
+++ b/regulations/static/regulations/css/less/module/comment-review.less
@@ -131,6 +131,13 @@ comment-review.less contains styles for Review Your Comment page
       text-align: right;
       max-width: 250px;
     }
+
+    .error {
+      border: none;
+      clear: left;
+      float: left;
+      padding: 0;
+    }
   }
 
   input[type=checkbox] {

--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -164,7 +164,7 @@ var CommentReviewView = Backbone.View.extend({
       contentType: 'application/json',
       dataType: 'json'
     });
-    $xhr.then(this.previewSuccess.bind(this));
+    $xhr.then(this.previewSuccess.bind(this), this.previewError.bind(this));
     this.previewLoading = true;
     this.render();
   },
@@ -173,6 +173,13 @@ var CommentReviewView = Backbone.View.extend({
     window.location = resp.url;
     this.previewLoading = false;
     this.render();
+  },
+
+  previewError: function(resp, status, error) {
+    this.previewLoading = false;
+    this.render();
+
+    this.$el.find('.download-comment').find('.details').after('<div class="error">There was an error in building the PDF.</div>');
   },
 
   toggleSubmit: function() {


### PR DESCRIPTION
Show an error message when PDF download fails on Review page.

<img width="812" alt="screen shot 2016-06-10 at 4 51 02 pm" src="https://cloud.githubusercontent.com/assets/24054/15981536/b7da9f04-2f2b-11e6-9897-c9ae2cdf6884.png">

Fixes one of: eregs/notice-and-comment#288