### PR TITLE
Add warnings for non-JS, non-localstorage users

### DIFF
--- a/regulations/static/regulations/js/source/views/main/main-view.js
+++ b/regulations/static/regulations/js/source/views/main/main-view.js
@@ -266,7 +266,10 @@ var MainView = Backbone.View.extend({
         this.loading();
     },
 
-    displayError: function() {
+    displayError: function(message) {
+        if (!message) {
+          message = 'Due to a network error, we were unable to retrieve the requested information.';
+        }
         // Prevent error warning stacking
         $('.error-network').remove();
 
@@ -278,7 +281,7 @@ var MainView = Backbone.View.extend({
           .prepend(
             '<div class="error error-network">' +
               '<span class="cf-icon cf-icon-error icon-warning"></span>' +
-              'Due to a network error, we were unable to retrieve the requested information.' +
+              message +
             '</div>'
           )
           .hide()

--- a/regulations/static/regulations/js/source/views/main/preamble-view.js
+++ b/regulations/static/regulations/js/source/views/main/preamble-view.js
@@ -102,8 +102,31 @@ var PreambleView = ChildView.extend({
     );
   },
 
+  cantWriteMessage: [
+    'Your browser does not support localStorage, which is currently required',
+    'to <em>submit</em> comments through this system. To find alternative',
+    'comment submission methods, please read the agency instructions as',
+    'listed in the preamble. We apologize for the inconvenience, but hope to',
+    'remove this limitation soon.'
+  ].join(' '),
+  /**
+   * We rely on localStorage for commenting at the moment. If it's not
+   * available, let the user know. TODO: replace with Modernizr/similar
+   **/
+  checkCanWrite: function() {
+    try {
+      localStorage.setItem('_test', 'value');
+      if (localStorage.getItem('_test') !== 'value') {
+        MainEvents.trigger('section:error', this.cantWriteMessage);
+      }
+    } catch (e) {   // unfortunately, localStorage exception varies by browser
+      MainEvents.trigger('section:error', this.cantWriteMessage);
+    };
+  },
+
   write: function(section, tocId, indexes, label, $parent) {
     this.mode = 'write';
+    this.checkCanWrite();
 
     // Top-level sections and permalink sections use different markup;
     // find appropriate element on top-level sections. TODO: unify markup

--- a/regulations/templates/regulations/preamble-chrome.html
+++ b/regulations/templates/regulations/preamble-chrome.html
@@ -7,6 +7,14 @@
 
   <div id="content-body" class="main-content preamble-wrapper">
     <section id="content-wrapper">
+      <noscript>
+        <div class="error">
+          Javascript is currently required to <em>submit</em> comments through
+          this system. To find alternative comment submission methods, please
+          read the agency instructions as listed in the preamble. We apologize
+          for the inconvenience, but hope to remove this limitation soon.
+        </div>
+      </noscript>
       {% include "regulations/preamble-partial.html" %}
     </section>
   </div> <!-- /.main-content -->


### PR DESCRIPTION
We don't currently support this audience, so we should warn them where
relevant. For the latter, we could build another custom version of Modernizer,
but I'm not seeing any of our existing JS code check it, so I'm guessing it's
being phased out. Easy enough to write a manual test.

To test locally, try Safari's Privacy mode and write a comment.

Doesn't look nice, but I think it'll do.

<img width="1214" alt="screen shot 2016-06-10 at 9 20 31 pm" src="https://cloud.githubusercontent.com/assets/326918/15982268/468e077a-2f51-11e6-9650-b852ba6aeab2.png">
<img width="1246" alt="screen shot 2016-06-10 at 9 19 34 pm" src="https://cloud.githubusercontent.com/assets/326918/15982269/468ff99a-2f51-11e6-813a-33eb2f6ad426.png">

Resolves eregs/notice-and-comment#287