### PR TITLE
Color contrast updates

### DIFF
--- a/regulations/static/regulations/css/less/base-variables.less
+++ b/regulations/static/regulations/css/less/base-variables.less
@@ -23,10 +23,9 @@ variables.less contains all theme variable / variable overrides
 @pacific: #0072CE;
 @blue: #0072CE;
 @link_blue: #348dc9; /* blue used for link borders and search results */
-@blue_light: #E1F3F8;
+@blue_light: #E2F4F9;
 @light_neutral: #D7D2CB;
-@dark_gray: #797D81;
-; /* dark border */
+@dark_gray: #797D81; /* dark border */
 @bg_gray: #F7F8F9; /* background header */
 @medium_gray: #B8BABD; /* light border */
 @80_gray: #9A9DA1;

--- a/regulations/static/regulations/css/less/base-variables.less
+++ b/regulations/static/regulations/css/less/base-variables.less
@@ -30,6 +30,7 @@ variables.less contains all theme variable / variable overrides
 @bg_gray: #F7F8F9; /* background header */
 @medium_gray: #B8BABD; /* light border */
 @80_gray: #9A9DA1;
+@diff_gray: #767676;
 @dark_text: #666666;
 @mid_text: #43484E;
 @orange: #FBCD92;

--- a/regulations/static/regulations/css/less/module/comment-review.less
+++ b/regulations/static/regulations/css/less/module/comment-review.less
@@ -105,7 +105,7 @@ comment-review.less contains styles for Review Your Comment page
   }
 
   .download-comment {
-    background: @pacific_light;
+    background: @blue_light;
     border-top: 1px solid @text_area_border;
     padding: 10px 15px;
 
@@ -229,7 +229,7 @@ comment-review.less contains styles for Review Your Comment page
     }
 
     span {
-      color: @80_gray;
+      color: @diff_gray;
     }
 
     fieldset {

--- a/regulations/static/regulations/css/less/module/comment-review.less
+++ b/regulations/static/regulations/css/less/module/comment-review.less
@@ -125,7 +125,7 @@ comment-review.less contains styles for Review Your Comment page
     }
 
     .details {
-      color: @80_gray;
+      color: @dark_text;
       float: right;
       font-size: 14px;
       text-align: right;

--- a/regulations/static/regulations/css/less/module/diffs.less
+++ b/regulations/static/regulations/css/less/module/diffs.less
@@ -1,12 +1,12 @@
 /*
  Diffs
- ========================================================================== 
+ ==========================================================================
  diffs.less defines the visual appearance of regulations additions and deletions
  */
 
 
 del {
-    color: @medium_gray;
+    color: @diff_gray;
     text-decoration: line-through;
 
     img {
@@ -24,10 +24,10 @@ ins {
         background-color: @green_light;
         text-decoration: none;
         .font-italic;
-        
+
         .level-2 &,
         .supplement-section .level-1 & {
-          .font-italic; 
+          .font-italic;
         }
     }
 


### PR DESCRIPTION
Update colors to meet accessible contrast ratios:
- CFR diff text
- Review page details

For eregs/notice-and-comment#377

<img width="618" alt="screen shot 2016-06-13 at 3 37 30 pm" src="https://cloud.githubusercontent.com/assets/24054/16025521/c601a48a-317c-11e6-9514-4640c7291d22.png">

---

<img width="819" alt="screen shot 2016-06-13 at 3 34 41 pm" src="https://cloud.githubusercontent.com/assets/24054/16025524/c878d256-317c-11e6-802b-c3ac49cd340f.png">
