### PR TITLE
Fix tab color issue

### DIFF
--- a/regulations/static/regulations/css/less/module/drawer.less
+++ b/regulations/static/regulations/css/less/module/drawer.less
@@ -176,8 +176,6 @@ currently these are TOC, History, and Search
     width: 56px;
     text-align: center;
     color: @dark_gray;
-    background-color: @light_field;
-    vertical-align: center;
 
     &.current {
         background-color: @light_field;


### PR DESCRIPTION
Also removes "vertical-align: center", which isn't a valid CSS rule.

<img width="357" alt="screen shot 2016-06-14 at 12 47 25 pm" src="https://cloud.githubusercontent.com/assets/326918/16051604/6ca9f9c0-322e-11e6-9b0d-c9c66271ed9a.png">
<img width="351" alt="screen shot 2016-06-14 at 12 45 49 pm" src="https://cloud.githubusercontent.com/assets/326918/16051605/6cc0b4f8-322e-11e6-9392-5182f3ebc6c3.png">

Does not affect notice-and-comment, where the values are overwritten.

Resolves eregs/notice-and-comment#150