### PR TITLE
Add blocks for customizing the TOC drawer

### DIFF
--- a/regulations/static/regulations/css/less/module/header.less
+++ b/regulations/static/regulations/css/less/module/header.less
@@ -7,7 +7,7 @@
     color: @dark_field;
     .font-regular;
     position: absolute;
-    height: @mainhead_height;
+    height: @mainhead_height + @subhead_height;
 
     ul {
         padding: 0;

--- a/regulations/templates/regulations/chrome.html
+++ b/regulations/templates/regulations/chrome.html
@@ -33,8 +33,10 @@
 {% include "regulations/main-header.html" %}
 
 <div class="sub-head {% block sub-head-class %}{% endblock %}">
-    {% block sub-head-drawer-icons %}
+    {% block sub-head-skip-nav %}
     <a href="#content-wrapper" class="hidden-text">Skip to main content</a> <!-- skip to content link for screen readers-->
+    {% endblock %}
+    {% block sub-head-drawer-icons %}
     <div class="toc-head">
         {% block sidebar-drawer-icons %}
         <a href="#" id="panel-link" class="toc-toggle panel-slide">

--- a/regulations/templates/regulations/chrome.html
+++ b/regulations/templates/regulations/chrome.html
@@ -33,6 +33,7 @@
 {% include "regulations/main-header.html" %}
 
 <div class="sub-head {% block sub-head-class %}{% endblock %}">
+    {% block sub-head-drawer-icons %}
     <a href="#content-wrapper" class="hidden-text">Skip to main content</a> <!-- skip to content link for screen readers-->
     <div class="toc-head">
         {% block sidebar-drawer-icons %}
@@ -58,6 +59,8 @@
           {% endblock %}
         </ul>
     </div> <!-- /toc-head-->
+    {% endblock %}
+    {% block sub-head-content %}
     <div id="content-header" class="header-main group">
         <div class="wayfinding">
           {% block wayfinding %}
@@ -69,6 +72,7 @@
         <span class="effective-date"><strong>Effective Date:</strong> {{ meta.effective_date|date }}</span>
         {% endblock %}
     </div>
+    {% endblock %}
 </div>
 </header>
 

--- a/regulations/templates/regulations/toc.html
+++ b/regulations/templates/regulations/toc.html
@@ -3,9 +3,11 @@
 {% endcomment %}
 <div {% if top_toc %}class="toc-drawer toc-container current hidden" id="table-of-contents"{% endif %}>
     {% if top_toc %}
+    {% block header %}
         <div class="drawer-header">
             <h2 class="toc-type">Table of Contents</h2>
         </div><!-- /.drawer-header -->
+    {% endblock %}
     {% endif %}
     <nav {% if top_toc %}id="toc" data-toc-version="{{ version }}" {% endif %}class="{{nav_class}} {% if top_toc %}drawer-content{% endif %}" role="navigation">
         <ol>


### PR DESCRIPTION
- Typo with the reg-head height, it should contain the sub-head height
- Adds block for the sub-head drawer icons
- Adds block for sub-head content