### PR TITLE
adding more blocks for more reuse in fec-eregs

### DIFF
--- a/regulations/templates/regulations/generic_universal.html
+++ b/regulations/templates/regulations/generic_universal.html
@@ -27,6 +27,7 @@
 
 <div class="landing-content">
 
+{% block hero %}
 <div class="hero">
     <div class="inner-wrap group">
       <div class="primary">
@@ -37,16 +38,20 @@
       </div>
     </div> <!-- /.inner-wrap -->
 </div> <!-- /.hero -->
+{% endblock %}
 
 <div class="landing-main" role="main">
   <div class="inner-wrap">
 
     <div class="group">
       <div class="content-primary column-l bump">
+        {% block regulations-title %}
         <h2 class="small-header light-header">
             {% block cfr_title %}Title {{cfr_title_number|upper}} {{cfr_title_text}}{% endblock %}
         </h2>
+        {% endblock %}
 
+        {% block reg-list %}
         <ul class="reg-list">
             {% for regulation in regulations %}
                 <li>
@@ -72,6 +77,7 @@
                 </li>
             {% endfor %}
         </ul>
+        {% endblock %}
 
         {% block moreregulations %}
         {% endblock %}

--- a/regulations/templates/regulations/generic_universal.html
+++ b/regulations/templates/regulations/generic_universal.html
@@ -87,9 +87,8 @@
         {% endblock %}
     </div> <!-- /.group -->
 
-
+      {% block about-eregs %}
       <section class="about bump group">
-        {% block about-eregs %}
         <h2 class="light-header">About eRegulations</h2>
         <div class="content-primary column-l">
 
@@ -100,7 +99,6 @@
 
           <p><a href="{% url 'about' %}" class="go">Learn more about eRegulations&#8217; features</a></p>
         </div> <!-- /.primart -->
-        {% endblock %}
 
         {% block orgcontact %}
         {% endblock %}
@@ -108,6 +106,7 @@
         {% block legal %}
         {% endblock %}
       </section> <!-- /.about -->
+      {% endblock %}
   </div> <!-- /.inner-wrap -->
 </div> <!-- /.landing-main -->
 

--- a/regulations/templates/regulations/generic_universal.html
+++ b/regulations/templates/regulations/generic_universal.html
@@ -87,7 +87,9 @@
         {% endblock %}
     </div> <!-- /.group -->
 
+
       <section class="about bump group">
+        {% block about-eregs %}
         <h2 class="light-header">About eRegulations</h2>
         <div class="content-primary column-l">
 
@@ -98,6 +100,7 @@
 
           <p><a href="{% url 'about' %}" class="go">Learn more about eRegulations&#8217; features</a></p>
         </div> <!-- /.primart -->
+        {% endblock %}
 
         {% block orgcontact %}
         {% endblock %}


### PR DESCRIPTION
This adds blocks for the hero, title, and regulations list on the generic_universal page so that those components can be deleted or reused in fec-eregs.