### PR TITLE
Add Django 1.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
 matrix:
   include:
     - python: '2.7'
-    - python: '3.3'
     - python: '3.4'
     - python: '3.5'
     - python: '3.5'

--- a/regulations/generator/html_builder.py
+++ b/regulations/generator/html_builder.py
@@ -163,7 +163,9 @@ class CFRHTMLBuilder(HTMLBuilder):
         #   ['105', '22', 'Interp'] => section header
         node['section_header'] = len(node['label']) == 3
 
-        is_header = lambda child: child['label'][-1] == 'Interp'
+        def is_header(child):
+            return child['label'][-1] == 'Interp'
+
         node['header_children'] = list(filter(is_header, node['children']))
         node['par_children'] = list(filterfalse(is_header, node['children']))
         if 'header' in node:
@@ -211,7 +213,10 @@ class PreambleHTMLBuilder(HTMLBuilder):
         super(PreambleHTMLBuilder, self).process_node(node, indexes=indexes)
         node['accepts_comments'] = True
         node['comments_calledout'] = bool(node.get('title'))
-        not_markerless = lambda l: not node_types.MARKERLESS_REGEX.match(l)
+
+        def not_markerless(l):
+            return not node_types.MARKERLESS_REGEX.match(l)
+
         markers = takewhile(not_markerless, node['label'][:4])
         node['toc_id'] = '-'.join(self.id_prefix + list(markers))
 

--- a/regulations/generator/node_types.py
+++ b/regulations/generator/node_types.py
@@ -63,9 +63,12 @@ def label_to_text(label, include_section=True, include_marker=False):
 MARKERLESS_REGEX = re.compile(r'^[hp]\d+')
 
 
+def _not_markerless(l):
+    return not MARKERLESS_REGEX.match(l)
+
+
 def take_until_markerless(label_parts):
-    not_markerless = lambda l: not MARKERLESS_REGEX.match(l)
-    return list(takewhile(not_markerless, label_parts))
+    return list(takewhile(_not_markerless, label_parts))
 
 
 def _join_paragraph_tail(label_parts, join_with, prefix='', suffix=''):

--- a/regulations/tests/tasks_tests.py
+++ b/regulations/tests/tasks_tests.py
@@ -6,7 +6,7 @@ import botocore
 from celery.exceptions import Retry, MaxRetriesExceededError
 from django.conf import settings
 from django.test import TestCase, override_settings
-from nose.tools import *  # noqa
+from nose.tools import assert_equal
 from requests.exceptions import RequestException
 
 from regulations.tasks import submit_comment, cache_pdf, SignedUrl

--- a/regulations/tests/views_preamble_tests.py
+++ b/regulations/tests/views_preamble_tests.py
@@ -4,7 +4,7 @@ from mock import patch
 from unittest import TestCase
 from datetime import date, timedelta
 
-from nose.tools import *  # noqa
+from nose.tools import assert_equal, assert_is_none
 from django.http import Http404
 from django.test import RequestFactory, override_settings
 

--- a/regulations/uitests/comment_test.py
+++ b/regulations/uitests/comment_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from nose.tools import *  # noqa
+from nose.tools import assert_equal, assert_in
 from selenium.webdriver.support.ui import WebDriverWait
 
 from regulations.uitests.base_test import BaseTest

--- a/regulations/uitests/scroll_test.py
+++ b/regulations/uitests/scroll_test.py
@@ -1,7 +1,7 @@
 # vim: set encoding=utf-8
 import unittest
 
-from nose.tools import *  # noqa
+from nose.tools import assert_equal
 from selenium.webdriver.support.ui import WebDriverWait
 
 from regulations.uitests.base_test import BaseTest

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -42,8 +42,7 @@ lt_cache = cache_page(settings.CACHES['eregs_longterm_cache']['TIMEOUT'],
                       cache='eregs_longterm_cache')
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', universal, name='universal_landing'),
     # about page
     url(r'^about$', about, name='about'),
@@ -186,4 +185,4 @@ urlpatterns = patterns(
     url(r'^partial/%s/%s$' % (paragraph_pattern, version_pattern),
         lt_cache(PartialParagraphView.as_view()),
         name='partial_paragraph_view'),
-)
+]

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.decorators.cache import cache_page
 
 from regulations.views.about import about

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'boto3',
         'cached-property',
         'celery',
-        'django>=1.8,<1.9',
+        'django>=1.8,<1.10',
         'enum34',
         'requests',
         'six',


### PR DESCRIPTION
Worked out of the box, but this patch removes a deprecation warning. Switching
`urlpatterns` to a list has been supported since 1.8 and will be required in
1.10