### PR TITLE
Mobile review page updates

### DIFF
--- a/regulations/static/regulations/css/less/layout.less
+++ b/regulations/static/regulations/css/less/layout.less
@@ -14,6 +14,7 @@ Main Content
 */
 
 .main-content {
+    background: @white;
     margin-top: @mainhead_height + @subhead_height;
     padding: 10px 60px 40px;
 }

--- a/regulations/static/regulations/css/less/module/comment-media-queries.less
+++ b/regulations/static/regulations/css/less/module/comment-media-queries.less
@@ -147,6 +147,13 @@ comment-media-queries.less contains media query styles for Notice and Comment
     }
   }
 
+  .comment-review {
+    .download-comment .details {
+      float: none;
+      text-align: left;
+    }
+  }
+
   .next-prev {
     .border-top-medium (@width: 2px);
   }

--- a/regulations/static/regulations/css/less/module/comment-media-queries.less
+++ b/regulations/static/regulations/css/less/module/comment-media-queries.less
@@ -341,7 +341,7 @@ comment-media-queries.less contains media query styles for Notice and Comment
     }
   }
 
-  #comment-review {
+  .comment-review {
     padding-left: 0;
 
     .comments ul {
@@ -355,12 +355,18 @@ comment-media-queries.less contains media query styles for Notice and Comment
     }
 
     .download-comment .details {
+      float: none;
       font-size: 12px;
+      text-align: left;
     }
 
     .additional-info {
 
       .tabs {
+        margin-bottom: 0;
+      }
+
+      .tabs a {
         margin-bottom: 5px;
       }
 
@@ -368,6 +374,26 @@ comment-media-queries.less contains media query styles for Notice and Comment
         margin-bottom: 5px;
       }
     }
+
+    .comment-disclaimer {
+      font-size: 16px;
+
+      input#agree {
+        float: left;
+      }
+
+      label {
+        float: left;
+        margin: -7px 0 25px 0;
+        width: 90%;
+      }
+
+      .required {
+        display: block;
+        margin: 0;
+      }
+    }
+
   }
 
   .section-nav .previous {


### PR DESCRIPTION
Fix mobile review page style regressions from earlier style cleanup and addressed some design tweaks on eregs/notice-and-comment#356:
- "This does not include your attachments" left aligned
- Additional info tab spacing
- "I read and understand" font size and aligned with checkbox

<img width="324" alt="screen shot 2016-06-17 at 12 02 42 am" src="https://cloud.githubusercontent.com/assets/24054/16143068/426cd2de-341f-11e6-9ef6-f9e0b0408a20.png">

---

<img width="323" alt="screen shot 2016-06-17 at 12 02 57 am" src="https://cloud.githubusercontent.com/assets/24054/16143072/46279e18-341f-11e6-9a66-1a84d2ec984c.png">

---

<img width="320" alt="screen shot 2016-06-17 at 12 03 11 am" src="https://cloud.githubusercontent.com/assets/24054/16143075/49f9c5f2-341f-11e6-85e0-ee73c7c14d03.png">
