### PR TITLE
Base section offsets on header size

### DIFF
--- a/regulations/static/regulations/css/less/layout.less
+++ b/regulations/static/regulations/css/less/layout.less
@@ -15,7 +15,7 @@ Main Content
 
 .main-content {
     margin-top: @mainhead_height + @subhead_height;
-    padding: 10px 60px 40px;
+    padding: 0 60px 40px;
 }
 
 @media only screen and ( max-width: 600px ) {
@@ -241,16 +241,16 @@ Section Offsets
     .footnotes li:before {
         display: block;
         content: "";
-        height: 100px;
-        margin: -100px 0 0;
+        height: @mainhead_height + @subhead_height;
+        margin: -1 * (@mainhead_height + @subhead_height) 0 0;
         visibility: hidden;
     }
 
     .reg-section .level-1 li,
     .appendix-section .level-1 li,
     .supplement-section .level-1 li {
-        border-top: 100px solid transparent;
-        margin-top: -100px;
+        border-top: @mainhead_height + @subhead_height solid transparent;
+        margin-top: -1 * (@mainhead_height + @subhead_height);
         -webkit-background-clip:padding-box;
         -moz-background-clip:padding;
         background-clip:padding-box;

--- a/regulations/static/regulations/js/source/views/main/child-view.js
+++ b/regulations/static/regulations/js/source/views/main/child-view.js
@@ -82,7 +82,7 @@ var ChildView = Backbone.View.extend({
     // for the fixed position header, is deemed the active section
     checkActiveSection: function() {
       $.each(this.$sections, function(idx, $section) {
-        if ($section.offset().top + this.$contentHeader.height() >= $(window).scrollTop()) {
+        if ($section.offset().top >= $(window).scrollTop()) {
           if (_.isEmpty(this.activeSection) || (this.activeSection !== $section.id)) {
             this.activeSection = $section[0].id;
             this.$activeSection = $($section[0]);
@@ -108,10 +108,9 @@ var ChildView = Backbone.View.extend({
 
     updateWayfinding: function() {
       // cache all sections in the DOM eligible to be the active section
-      // also cache some jQobjs that we will refer to frequently
-      this.$contentHeader = this.$contentHeader || $('header.reg-header');
-
-      // sections that are eligible for being the active section
+      // also cache some jQobjs that we will refer to frequently.
+      //
+      // Sections that are eligible for being the active section.
       this.$sections = this.$el
         .find('li[id], .reg-section, .appendix-section, .supplement-section')
         .map(function(idx, elm) {

--- a/regulations/static/regulations/js/source/views/main/child-view.js
+++ b/regulations/static/regulations/js/source/views/main/child-view.js
@@ -11,6 +11,10 @@ var MainEvents = require('../../events/main-events');
 var GAEvents = require('../../events/ga-events');
 Backbone.$ = $;
 
+// Adjust the offset of how far past the section top before the wayfinder
+// changes. Based on 2 * line-height + padding-top.
+var WAYFINDER_SCROLL_OFFSET = window.WAYFINDER_SCROLL_OFFSET || 64;
+
 var ChildView = Backbone.View.extend({
     el: '#content-wrapper',
 
@@ -79,10 +83,11 @@ var ChildView = Backbone.View.extend({
     // naive way to update the active table of contents link and wayfinding header
     // once a scroll event ends, we loop through each content section DOM node
     // the first one whose offset is greater than the window scroll position, accounting
-    // for the fixed position header, is deemed the active section
+    // for the fixed position header (via margin/border offsets), is deemed the
+    // active section
     checkActiveSection: function() {
       $.each(this.$sections, function(idx, $section) {
-        if ($section.offset().top >= $(window).scrollTop()) {
+        if ($section.offset().top + WAYFINDER_SCROLL_OFFSET >= $(window).scrollTop()) {
           if (_.isEmpty(this.activeSection) || (this.activeSection !== $section.id)) {
             this.activeSection = $section[0].id;
             this.$activeSection = $($section[0]);

--- a/regulations/static/regulations/js/source/views/main/main-view.js
+++ b/regulations/static/regulations/js/source/views/main/main-view.js
@@ -22,7 +22,6 @@ var HeaderEvents = require('../../events/header-events');
 var DrawerEvents = require('../../events/drawer-events');
 var Helpers = require('../../helpers');
 var MainEvents = require('../../events/main-events');
-var ChildView = require('./child-view');
 var CommentReviewView = require('../comment/comment-review-view');
 var CommentConfirmView = require('../comment/comment-confirm-view');
 var PreambleView = require('./preamble-view');


### PR DESCRIPTION
- Remove padding on .main-content that throws off the wayfinder calculation
- Use offests based on header size for desktop

I haven't touched mobile yet. @cmc333333 pointed out in slack that this is still missing. We don't specify the mobile header size as a variable, and I'm reluctant to add more variables. If that's the best way, then so be it. Any other thoughts?