### PR TITLE
Fix error collecting versions for CFR viewer

### DIFF
--- a/regulations/generator/versions.py
+++ b/regulations/generator/versions.py
@@ -47,9 +47,9 @@ def fetch_grouped_history(part):
 
     for notice in client.notices(part)['results']:
         notice = convert_to_python(notice)
-        for v in (v for v in versions
-                  if v['by_date'] == notice['effective_on']):
-            v['notices'].append(notice)
+        for version in versions:
+            if version['by_date'] == notice.get('effective_on'):
+                version['notices'].append(notice)
 
     for version in versions:
         version['notices'] = sorted(version['notices'], reverse=True,

--- a/regulations/tests/generator_versions_tests.py
+++ b/regulations/tests/generator_versions_tests.py
@@ -28,7 +28,8 @@ class VersionsTest(TestCase):
         n4 = {'effective_on': future, 'publication_date': '2005-05-05'}
         n5 = {'effective_on': future, 'publication_date': '2005-06-05'}
         n6 = {'effective_on': future, 'publication_date': '2005-07-05'}
-        client.notices.return_value = {'results': [n1, n2, n3, n5, n4, n6]}
+        n7 = {'publication_date': '2001-02-02'}     # proposal
+        client.notices.return_value = {'results': [n1, n2, n3, n5, n4, n6, n7]}
 
         history = versions.fetch_grouped_history('111')
         self.assertEqual(3, len(history))


### PR DESCRIPTION
Small change which allows a notice-and-comment site to display the CFR without
exploding.