### PR TITLE
Print CSS 

### DIFF
--- a/regulations/static/regulations/css/less/print.less
+++ b/regulations/static/regulations/css/less/print.less
@@ -139,6 +139,14 @@ footer.search-nav {
     padding: 0;
 }
 
+.dataTables_scrollHeadInner {
+  width: 100% !important;
+
+  table {
+    width: 100% !important;
+  }
+}
+
  /*
  Margin/Padding Resets
  ========================================================================== */

--- a/regulations/static/regulations/css/less/print.less
+++ b/regulations/static/regulations/css/less/print.less
@@ -139,6 +139,8 @@ footer.search-nav {
     padding: 0;
 }
 
+// overrides dynamic sizing done by the DataTables plugin which breaks in print mode
+
 .dataTables_scrollHeadInner {
   width: 100% !important;
 

--- a/regulations/static/regulations/css/less/print.less
+++ b/regulations/static/regulations/css/less/print.less
@@ -139,10 +139,6 @@ footer.search-nav {
     padding: 0;
 }
 
-.dataTables_scrollHeadInner {
-  width: 100%;
-}
-
  /*
  Margin/Padding Resets
  ========================================================================== */

--- a/regulations/static/regulations/css/less/print.less
+++ b/regulations/static/regulations/css/less/print.less
@@ -111,6 +111,21 @@ footer.search-nav {
  Print only the text of the regulation
  */
 
+#preamble-read {
+  width: 100%;
+  padding: 0 40px;
+  margin: 0 auto;
+
+  .activate-write {
+    display: none;
+  }
+
+  //removes indent on the first level of depth
+  .preamble-content > ul {
+    padding: 0;
+  }
+}
+
 .wrap,
 .main-content,
 .secondary-content,
@@ -122,6 +137,10 @@ footer.search-nav {
     float: none !important;
     margin: 0;
     padding: 0;
+}
+
+.dataTables_scrollHeadInner {
+  width: 100%;
 }
 
  /*


### PR DESCRIPTION
Adding some print CSS that removes the "add a comment" links and makes the content 100% width with some small padding on each side.

<img width="250" alt="screen shot 2016-06-22 at 5 55 31 pm" src="https://cloud.githubusercontent.com/assets/776987/16286516/8f3f420e-38a2-11e6-8b36-3b517270ec49.png">
