### PR TITLE
Refer to correct element

### DIFF
--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -24,7 +24,7 @@ var CommentReviewView = Backbone.View.extend({
   events: {
     'click .edit-comment': 'editComment',
     'click .preview-button': 'preview',
-    'change .agree': 'toggleSubmit'
+    'change #agree': 'toggleSubmit'
   },
 
   initialize: function(options) {
@@ -45,7 +45,7 @@ var CommentReviewView = Backbone.View.extend({
   findElms: function() {
     this.$form = this.$el.find('form');
     this.$submit = this.$el.find('.submit-button');
-    this.$agree = this.$el.find('.agree');
+    this.$agree = this.$el.find('#agree');
   },
 
   editComment: function(e) {


### PR DESCRIPTION
We switched an element from using a class to an id, but didn't update the
corresponding JS.

Resolves eregs/notice-and-comment#400

<img width="526" alt="screen shot 2016-06-23 at 6 17 21 pm" src="https://cloud.githubusercontent.com/assets/326918/16322128/09868f50-396f-11e6-83d3-a3cf471da8ed.png">
<img width="513" alt="screen shot 2016-06-23 at 6 17 27 pm" src="https://cloud.githubusercontent.com/assets/326918/16322130/0cea94b6-396f-11e6-8a5a-6955d665f277.png">