### PR TITLE
Disable linting on code climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,8 +5,6 @@ engines:
       languages:
       - javascript
       - python
-  eslint:
-    enabled: true
   markdownlint:
     enabled: true
   pep8:


### PR DESCRIPTION
We haven't configured it yet, so it's complaining. We don't actually use
eslint yet, so its initial inclusion was more aspirational that useful.