### PR TITLE
Set version to 5.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ class bdist_egg(_bdist_egg):
 
 setup(
     name="regulations",
-    version="2.0.0",
+    version="5.0.0",
     packages=find_packages(),
     install_requires=[
         'boto3',


### PR DESCRIPTION
We've gone through several iterations since "2.0.0" was selected. Let's say
we're on 5.0.0 based on these sub-projects:

1.0 - CFPB reg E
2.0 - CFPB reg Z
3.0 - ATF 479
4.0 - all ATF regs
5.0 - N&C