### PR TITLE
cfr viewer polish

### DIFF
--- a/regulations/static/regulations/css/less/base-variables.less
+++ b/regulations/static/regulations/css/less/base-variables.less
@@ -85,5 +85,5 @@ Layout Variables
 */
 
 @closed_drawer_width: 40px;
-@mainhead_height: 60px; // Height of your .main-head element. Used to calculate the fixed offsets.
+@mainhead_height: 56px; // Height of your .main-head element. Used to calculate the fixed offsets.
 @subhead_height: 34px;  // Height of your .sub-head element. Used to calculate the fixed offsets.

--- a/regulations/static/regulations/css/less/module/drawer-content.less
+++ b/regulations/static/regulations/css/less/module/drawer-content.less
@@ -247,7 +247,6 @@ This contains all of the styles specific to the history
         .reset;
         font-size: 0.875em;
         text-transform: uppercase;
-        color: @dark_text;
         line-height: normal;
     }
 
@@ -255,7 +254,6 @@ This contains all of the styles specific to the history
         .reset;
         font-size: 0.875em;
         text-transform: uppercase;
-        color: @dark_text;
         line-height: normal;
     }
 

--- a/regulations/static/regulations/css/less/module/drawer-content.less
+++ b/regulations/static/regulations/css/less/module/drawer-content.less
@@ -100,7 +100,6 @@ This contains all of the styles specific to the TOC
     padding: 7px 15px 8px 105px;
     margin-left: -100px;
     line-height: 1.3;
-    outline: none;
   }
 
   a:link,

--- a/regulations/static/regulations/css/less/module/drawer-content.less
+++ b/regulations/static/regulations/css/less/module/drawer-content.less
@@ -11,6 +11,7 @@ This contains all of the styles specific to the TOC
 
     .toc-item {
       padding: 7px 15px 5px 5px;
+      margin-left: 0;
       text-indent: -15px;
     }
 
@@ -23,6 +24,7 @@ This contains all of the styles specific to the TOC
     a:active,
     .current {
       padding-left: 105px;
+      margin-left: -100px;
     }
 
     .toc-entry-at-1, .toc-entry-at-1:hover {
@@ -61,6 +63,12 @@ This contains all of the styles specific to the TOC
     }
   }
 
+  &.cfr-nav {
+    .subpart-heading {
+      .border-top-light (@width: 1px);
+    }
+  }
+
   ol {
     margin: 0;
     padding: 0;
@@ -89,8 +97,10 @@ This contains all of the styles specific to the TOC
 
   a {
     display: block;
-    padding: 7px 15px 8px 5px;
+    padding: 7px 15px 8px 105px;
+    margin-left: -100px;
     line-height: 1.3;
+    outline: none;
   }
 
   a:link,
@@ -148,7 +158,6 @@ This contains all of the styles specific to the TOC
     line-height: 1.4;
     background-color: #F8F8F8;
     .border-bottom-light (@width: 1px);
-    .border-top-light (@width: 1px);
     .regulation-nav-subpart-heading-font;
 }
 

--- a/regulations/static/regulations/css/less/module/drawer.less
+++ b/regulations/static/regulations/css/less/module/drawer.less
@@ -33,7 +33,7 @@ Universal drawer styles
   a:hover,
   a.current {
     background-color: @white;
-    color: @link_blue;
+    color: @blue;
     height: 34px;
   }
 

--- a/regulations/static/regulations/css/less/module/header.less
+++ b/regulations/static/regulations/css/less/module/header.less
@@ -27,7 +27,7 @@
     top: 0;
     width: 100%;
     z-index: 1000;
-    height: 3.75em;
+    height: @mainhead_height;
 }
 
 .title {

--- a/regulations/static/regulations/css/less/module/sidebar.less
+++ b/regulations/static/regulations/css/less/module/sidebar.less
@@ -75,7 +75,7 @@ Sidebar Expandables
         a {
             float: right;
             font-size: 0.875em;
-            line-height: 30px;
+            line-height: 40px;
             margin-right: 25px;
         }
     }

--- a/regulations/templates/regulations/preamble-base.html
+++ b/regulations/templates/regulations/preamble-base.html
@@ -48,7 +48,7 @@
       <h2 class="toc-type">Table of Contents</h2>
       <h3 class="toc-subheader">Amendments to the CFR</h3>
     </div>
-    <nav id="cfr-toc" class="regulation-nav drawer-content preamble-nav" role="navigation">
+    <nav id="cfr-toc" class="regulation-nav drawer-content preamble-nav cfr-nav" role="navigation">
       <ol>
         {% for cfr_part_toc in cfr_change_toc %}
           <li>


### PR DESCRIPTION
A few changes to make sure this looks right on the CFR viewer and some polish on non-viewer parts.

Note: I added a class for the ToC on the CFR tab so it could be styled the way it is currently on master while allowing the cfr viewer navigation to look correct. This process also cleaned up some random `<li>`s on the cfr viewer nav having double-thick border lines when they shouldn't have.

I think this may be everything that has to be complete before I can start safely renaming color  and font variables so let me know if there's something I overlooked before I proceed. 

<img width="638" alt="screen shot 2016-06-24 at 5 06 15 pm" src="https://cloud.githubusercontent.com/assets/776987/16351793/01667a14-3a2e-11e6-8e3d-9e714d54ae27.png">
