### PR TITLE
Add timeout to regulations.gov requests

### DIFF
--- a/regulations/docket.py
+++ b/regulations/docket.py
@@ -14,6 +14,7 @@ cache = caches['regs_gov_cache']
 def fetch(url, **kwargs):
     kwargs['headers'] = kwargs.get(
         'headers', {'X-Api-Key': settings.REGS_GOV_API_KEY})
+    kwargs['timeout'] = kwargs.get('timeout', 10)   # timeout after 10 seconds
     response = requests.get(url, **kwargs)
     if response.status_code != requests.codes.ok:
         response.raise_for_status()
@@ -49,7 +50,7 @@ def safe_get_document_fields(document_id):
     """Like get_document_fields, but returns None on error"""
     try:
         return get_document_fields(document_id)
-    except requests.exceptions.HTTPError as e:
+    except requests.exceptions.RequestException as e:
         logger.warning("Error getting data from regs.gov: %s", e)
         return None
 

--- a/regulations/tests/sanitize_fields_tests.py
+++ b/regulations/tests/sanitize_fields_tests.py
@@ -2,6 +2,7 @@
 from django.test import TestCase
 from mock import patch
 import httpretty
+import requests
 
 from regulations.docket import sanitize_fields
 
@@ -77,6 +78,13 @@ class SanitizeFieldsHTTPErrorsTest(TestCase):
 
     def test_503(self):
         httpretty.register_uri(httpretty.GET, 'http://example.com', status=503)
+        with self.settings(REGS_GOV_API_URL='http://example.com'):
+            valid, message = sanitize_fields({'something': 'else'})
+        self.assertTrue(valid)
+
+    @patch('regulations.docket.requests.get')
+    def test_timeout(self, get):
+        get.side_effect = requests.Timeout
         with self.settings(REGS_GOV_API_URL='http://example.com'):
             valid, message = sanitize_fields({'something': 'else'})
         self.assertTrue(valid)


### PR DESCRIPTION
If a request to regulations.gov takes more than 10 seconds, we'll consider it
failed. We'll also catch _all_ `requests` exceptions (including
ConnectionErrors, HTTPErrors, Timeouts, and TooManyRedirects).

Resolves 18F/epa-notice#434