### PR TITLE
Color Variable Renaming

### DIFF
--- a/regulations/static/regulations/css/less2sass.sh
+++ b/regulations/static/regulations/css/less2sass.sh
@@ -79,7 +79,7 @@ sed -i.bak -e 's/\$page/@page/g' print.scss
 
 echo "renaming incompatible variables..."
 # can't start a sass variable with int
-find . -type f -exec sed -i.bak 's/\$80_gray/\$gray/g' {} \;
+find . -type f -exec sed -i.bak 's/\$80_gray/\$gray_80/g' {} \;
 
 # remove backup files from stream editing
 rm *.bak **/*.bak

--- a/regulations/static/regulations/css/less2sass.sh
+++ b/regulations/static/regulations/css/less2sass.sh
@@ -79,7 +79,7 @@ sed -i.bak -e 's/\$page/@page/g' print.scss
 
 echo "renaming incompatible variables..."
 # can't start a sass variable with int
-find . -type f -exec sed -i.bak 's/\$80_gray/\$gray_80/g' {} \;
+find . -type f -exec sed -i.bak 's/\$80_gray/\$gray/g' {} \;
 
 # remove backup files from stream editing
 rm *.bak **/*.bak

--- a/regulations/static/regulations/css/scss/base-variables.scss
+++ b/regulations/static/regulations/css/scss/base-variables.scss
@@ -8,70 +8,55 @@ variables.scss contains all theme variable / variable overrides
  ----------------
  */
 
-$green: #2CB34A;
-$green_midtone: #ADDC91;
-$green_light: #E7F4E4;
-$uswds_green: #2F8540;
-$black: #101820;
-$white: #FFFFFF;
-$dark_field: #5C6065;
-$light_field: #D1D3D5;
-$uswds_gray_lighter: #D6D7D9;
-$grey: #E6E7E9;
-$red_orange: #D12124;
-$uswds_dark_red: #CD2026;
-$pacific: #0072CE;
-$blue_light: #E2F4F9;
-$light_neutral: #D7D2CB;
-$dark_gray: #797D81; /* dark border */
-$bg_gray: #F7F8F9; /* background header */
-$medium_gray: #B8BABD; /* light border */
-$gray_80: #9A9DA1;
-$diff_gray: #767676;
-$dark_text: #666666;
-$mid_text: #43484E;
-$orange: #FBCD92;
-$light_orange: #FFECD1;
-$pacific_hover: #328ED8;
-$pacific_light: #CCE3F5;
-$red_orange_80: #D96A4F;
-$red_orange_50: #E9A193;
-$pink: #F9DEDE;
-
-$text_area_border: rgba(0, 0, 0, 0.25);
-
-$history_drawer_border_color: #d1d3d5;
-
-/*
- From N&C
- ----------------------
-*/
-
 $black: #212121;
 $white: #FFFFFF;
 
+// Greens
+
+$green: #2F8540;
+$green_light: #ADDC91;
+$green_lightest: #E7F4E4;
+
+
+// Greys
+
+$gray_darkest: #43484E;
+$gray_darker: #5C6065;
+$gray_dark: #797D81;
+$gray: #9A9DA1;
+$gray_light: #D8D8D8;
+$gray_lighter: #E6E7E9;
+$gray_lightest: #F5F5F5;
+
+
+// Blues
+
+$blue_dark: #1F5593;
 $blue: #205493;
-$light_blue: #A1CBFC;
-$dark_blue: #1F5593;
-$aqua_blue: #B3E0EB;
-$aqua_blue_2: #9BDAF1;
+$blue_light: #0071BC;
+$blue_lighter: #A1CBFC;
+$blue_lightest: #E1F3F8;
 
-$link_blue: #0071BC;
-$link_blue_inactive: #9BDAF1;
-$write_link_inactive: #457D9A;
 
-$gray_blue: #5B616B;
-$navigation_gray: #676767;
-$toc_highlight: #E1F3F8;
+// Oranges and Reds
 
-$light_gray: #F5F5F5;
-$gray: #D6D7D9;
-$dark_gray: #D8D8D8;
+$red: #CD2026;
+$red_light: #D96A4F;
+$red_lightest: #E9A193;
 
-$citation_gray: #767676;
+$pink: #F9DEDE;
 
-$light_orange: #FFF1D2;
 $orange: #FDB81E;
+$orange_light: #FBCD92;
+$orange-lightest: #FFECD1;
+
+/*
+Element Variables
+*/
+
+$text_area_border: rgba(0, 0, 0, 0.25);
+$history_drawer_border_color: #d1d3d5;
+
 
 /*
  Type Variables

--- a/regulations/static/regulations/css/scss/base-variables.scss
+++ b/regulations/static/regulations/css/scss/base-variables.scss
@@ -48,7 +48,7 @@ $pink: #F9DEDE;
 
 $orange: #FDB81E;
 $orange_light: #FBCD92;
-$orange-lightest: #FFECD1;
+$orange_lightest: #FFECD1;
 
 /*
 Element Variables

--- a/regulations/static/regulations/css/scss/base-variables.scss
+++ b/regulations/static/regulations/css/scss/base-variables.scss
@@ -7,7 +7,9 @@ variables.scss contains all theme variable / variable overrides
  Color Variables
  ----------------
  */
+// Black and white
 
+$black_dark: #111111;
 $black: #212121;
 $white: #FFFFFF;
 

--- a/regulations/static/regulations/css/scss/layout.scss
+++ b/regulations/static/regulations/css/scss/layout.scss
@@ -15,7 +15,7 @@ Main Content
 
 .main-content {
     background: $white;
-    margin-top: $mainhead_height + $subhead_height + 4px;
+    margin-top: $mainhead_height + $subhead_height + 4px; // 4px adds additional padding to the content area, preventing text from being squished against the subhead nav
     padding: 0 60px 40px;
 }
 

--- a/regulations/static/regulations/css/scss/layout.scss
+++ b/regulations/static/regulations/css/scss/layout.scss
@@ -15,7 +15,7 @@ Main Content
 
 .main-content {
     background: $white;
-    margin-top: $mainhead_height + $subhead_height;
+    margin-top: $mainhead_height + $subhead_height + 4px;
     padding: 0 60px 40px;
 }
 

--- a/regulations/static/regulations/css/scss/layout.scss
+++ b/regulations/static/regulations/css/scss/layout.scss
@@ -88,14 +88,14 @@ Secondary Content
     .secondary-content {
         position: fixed;
         overflow-y: auto;
-        border-left: 1px solid $light_field;
+        border-left: 1px solid $gray_light;
         top: $mainhead_height + $subhead_height;
         right: 0px;
         bottom: 0;
         height: 100%;
         width: 25%;
         padding-left: 0px;
-        background: #fff;
+        background: $white;
         z-index: 100;
         margin-left: 15px;
     }
@@ -182,9 +182,9 @@ TOC Header Navigation
     left: 0;
     width: 240px;
     height: 34px;
-    border-right: 2px solid $medium_gray;
+    border-right: 2px solid $gray_light;
     @include border-bottom-medium($width: 1px);
-    background-color: $bg_gray;
+    background-color: $gray_lightest;
 }
 
 .header-main { /* TODO: closely matches main content layout - should unify into single class*/

--- a/regulations/static/regulations/css/scss/main.scss
+++ b/regulations/static/regulations/css/scss/main.scss
@@ -119,7 +119,7 @@ Modules
 }
 
 .important {
-    color: $red_orange;
+    color: $red;
 }
 
 .alert {
@@ -138,7 +138,7 @@ Modules
 
 .well {
     padding: 1em 1.25em;
-    background: $bg_gray;
+    background: $gray_lightest;
 }
 
 .bump {
@@ -174,8 +174,8 @@ Modules
 
 .error {
     @include sans-font-regular;
-    color: $red_orange;
-    border-bottom: 1px solid $light_field;
+    color: $red;
+    border-bottom: 1px solid $gray_light;
     font-size: .9em;
     padding: 1em 0;
     line-height: 1.6em;
@@ -184,18 +184,18 @@ Modules
 .icon-warning {
     float: left;
     margin: .25em .5em 0 0;
-    color: $red_orange;
+    color: $red;
 }
 
 /* credit */
 #modal {
     @include sans-font-bold;
-    color: $dark_gray;
+    color: $gray_light;
     width: 400px;
     height: 400px;
     position: fixed;
     z-index: 9999;
-    border: 4px solid $gray_80;
+    border: 4px solid $gray;
     padding: 20px 40px;
 
     ul {
@@ -254,7 +254,7 @@ img.reg-image {
     margin-left: auto;
     margin-right: auto;
     display: block;
-    border: 1px solid $light_field;
+    border: 1px solid $gray_light;
 }
 
 .block-image {

--- a/regulations/static/regulations/css/scss/mixins.scss
+++ b/regulations/static/regulations/css/scss/mixins.scss
@@ -41,7 +41,7 @@ mixins.scss contains any mixins to be used throughout the LESS files
 
 @mixin drawer-header-font {
     @include sans-font-bold;
-    color: $mid_text;
+    color: $gray_darkest;
     font-size: .875em; /* 12px / (26px * .875em) */
     text-transform: uppercase;
 }
@@ -60,7 +60,7 @@ mixins.scss contains any mixins to be used throughout the LESS files
 @mixin regulation-nav-subpart-heading-font {
     font-size: 1em;
     text-transform: uppercase;
-    color: $mid_text;
+    color: $gray_darkest;
 }
 
 @mixin regulation-nav-interp-heading-font {
@@ -103,27 +103,27 @@ mixins.scss contains any mixins to be used throughout the LESS files
 */
 
 @mixin border-bottom-medium($width: 1px) {
-    border-bottom: $width solid $medium_gray;
+    border-bottom: $width solid $gray_light;
 }
 
 @mixin border-bottom-light($width: 1px) {
-    border-bottom: $width solid $light_field;
+    border-bottom: $width solid $gray_light;
 }
 
 @mixin border-bottom-dark($width: 1px) {
-    border-bottom: $width solid $dark_gray;
+    border-bottom: $width solid $gray_light;
  }
 
  @mixin border-top-light($width: 1px) {
-    border-top: $width solid $light_field;
+    border-top: $width solid $gray_light;
  }
 
  @mixin border-top-medium($width: 1px) {
-    border-top: $width solid $medium_gray;
+    border-top: $width solid $gray_light;
 }
 
 @mixin border-right-light($width: 1px) {
-    border-right: $width solid $light_field;
+    border-right: $width solid $gray_light;
 }
 
 /*

--- a/regulations/static/regulations/css/scss/module/about.scss
+++ b/regulations/static/regulations/css/scss/module/about.scss
@@ -157,7 +157,7 @@ custom styles
     border-radius: 4px;
     text-align: center;
     background: $gray_lightest;
-    color: $gray;
+    color: $gray_dark;
     font-size: 22px;
 }
 
@@ -189,7 +189,7 @@ custom styles
 
 .small-disclaimer {
     display: block;
-    color: $gray;
+    color: $gray_dark;
     line-height: 1.4;
 }
 

--- a/regulations/static/regulations/css/scss/module/about.scss
+++ b/regulations/static/regulations/css/scss/module/about.scss
@@ -33,7 +33,7 @@ hero
 */
 
 .title-hero {
-    background-color: $green_midtone;
+    background-color: $blue_lighter;
     @include border-bottom-light;
 
     h3 {
@@ -45,7 +45,7 @@ hero
 }
 
 .about-section {
-    border-bottom: 1px solid $medium_gray;
+    border-bottom: 1px solid $gray_light;
     padding-bottom: 1em;
 }
 
@@ -96,7 +96,7 @@ dev well
         height: 100px;
         margin-right: 16px;
         font-size: 1.5em;
-        color: $dark_gray;
+        color: $gray_light;
     }
 
 }
@@ -125,7 +125,7 @@ snazzy ordered lists
 .about-ol > li:before{
     content: counter(li);
     counter-increment: li;
-    background: $green;
+    background: $blue;
     color: #fff;
     font-size: 12px;
     position: absolute;
@@ -156,8 +156,8 @@ custom styles
     line-height: 46px;
     border-radius: 4px;
     text-align: center;
-    background: $bg_gray;
-    color: $gray_80;
+    background: $gray_lightest;
+    color: $gray;
     font-size: 22px;
 }
 
@@ -181,7 +181,7 @@ custom styles
     line-height: 1;
     -webkit-font-smoothing: antialiased;
     content: "\e642";
-    color: $green;
+    color: $blue;
     margin-left: -32px;
     padding-right: 12px;
     font-size: 18px;
@@ -189,7 +189,7 @@ custom styles
 
 .small-disclaimer {
     display: block;
-    color: $gray_80;
+    color: $gray;
     line-height: 1.4;
 }
 

--- a/regulations/static/regulations/css/scss/module/comment-confirm.scss
+++ b/regulations/static/regulations/css/scss/module/comment-confirm.scss
@@ -18,7 +18,7 @@ Contains styles for Comment confirmation success/fail/invalid pages.
     padding: 15px 10px 10px;
 
     &.success-alert {
-      background-color: $green_light;
+      background-color: $green_lightest;
     }
 
     &.fail-alert {
@@ -89,7 +89,7 @@ Contains styles for Comment confirmation success/fail/invalid pages.
   }
 
   section {
-    border-top: 1px solid $medium_gray;
+    border-top: 1px solid $gray_light;
     padding: 25px 0 35px;
 
     h4 {
@@ -127,7 +127,7 @@ Contains styles for Comment confirmation success/fail/invalid pages.
     }
 
     .status {
-      background-color: $blue_light;
+      background-color: $blue_lightest;
       padding: 8px 16px;
       margin: 0;
 
@@ -141,7 +141,7 @@ Contains styles for Comment confirmation success/fail/invalid pages.
     }
 
     .status-waiting {
-      background-color: $blue_light;
+      background-color: $blue_lightest;
       padding: 8px 16px;
       margin: 1px 0;
 
@@ -152,7 +152,7 @@ Contains styles for Comment confirmation success/fail/invalid pages.
     }
 
     .tracking-number-retrieved {
-      background-color: $green_light;
+      background-color: $green_lightest;
     }
   }
 
@@ -166,7 +166,7 @@ Contains styles for Comment confirmation success/fail/invalid pages.
       padding-left: 0;
 
       &:before {
-        border-color: transparent $orange;
+        border-color: transparent $orange_light;
         border-radius: 3px;
         border-style: solid;
         border-width: 8px 0 8px 13px;

--- a/regulations/static/regulations/css/scss/module/comment-media-queries.scss
+++ b/regulations/static/regulations/css/scss/module/comment-media-queries.scss
@@ -184,7 +184,7 @@ comment-media-queries.scss contains media query styles for Notice and Comment
   }
 
   .preamble-header {
-    background: $bg_gray;
+    background: $gray_lightest;
     left: 40px;
     z-index: 10;
 
@@ -198,8 +198,8 @@ comment-media-queries.scss contains media query styles for Notice and Comment
 
     .read-proposal,
     .write-comment {
-      border-bottom: 1px solid $medium_gray;
-      border-top: 1px solid $medium_gray;
+      border-bottom: 1px solid $gray_light;
+      border-top: 1px solid $gray_light;
       width: 50% !important;
     }
 

--- a/regulations/static/regulations/css/scss/module/comment-read.scss
+++ b/regulations/static/regulations/css/scss/module/comment-read.scss
@@ -42,8 +42,12 @@ Preamble Read Mode
     width: 250px;
 
     a {
-      color: $write_link_inactive;
+      color: $blue_light;
       display: block;
+
+      &:hover {
+        color: $blue;
+      }
     }
 
     // write a comment pencil icon font
@@ -65,9 +69,9 @@ Preamble Read Mode
 
   // hidden content (with stars) on CFR
   .show-more-context {
-    background-color: $light_gray;
+    background-color: $gray_lightest;
     border-radius: 2px;
-    color: $link_blue;
+    color: $blue_light;
     font-size: 10px;
     margin: 10px 0;
     text-align: center;
@@ -80,13 +84,13 @@ Preamble Read Mode
   }
 
   .subpart-info {
-    border-bottom: 1px solid $medium_gray;
+    border-bottom: 1px solid $gray_light;
     margin-bottom: 15px;
 
     .subpart-sections {
       font-size: 14px;
       @include sans-font-regular;
-      color: $dark_text;
+      color: $gray_darker;
       margin: 20px 0 0 0;
     }
 
@@ -99,10 +103,10 @@ Preamble Read Mode
       height: 10px;
       width: 10px;
       vertical-align: middle;
-      background-color: $grey;
+      background-color: $gray_lighter;
 
       &.current {
-        background-color: $pacific;
+        background-color: $blue_light;
       }
     }
   }
@@ -150,10 +154,10 @@ Preamble Read Mode
     color: $white;
 
     &.open {
-      background-color: $uswds_green;
+      background-color: $green;
     }
     &.closed {
-      background-color: $uswds_dark_red;
+      background-color: $red;
     }
 
     strong {
@@ -168,7 +172,7 @@ Preamble Read Mode
     @include sans-font-regular;
     margin: 30px 0 35px;
     padding-bottom: 40px;
-    border-bottom: 2px solid $uswds_gray_lighter;
+    border-bottom: 2px solid $gray_light;
 
     .fa {
       margin: 0 6px;

--- a/regulations/static/regulations/css/scss/module/comment-review.scss
+++ b/regulations/static/regulations/css/scss/module/comment-review.scss
@@ -194,10 +194,10 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
       cursor: pointer;
 
       &:hover {
-        background: darken($gray_lighter, 10%);
+        background: $gray_light;
       }
       &:active, &.current {
-        background: darken($gray_lighter, 20%);
+        background: $gray_light;
       }
     }
 
@@ -245,7 +245,7 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
       height: auto;
       border-radius: 3px;
       border: 1px solid rgba(0,0,0,.25);
-      box-shadow: inset 0 0 1px fade($gray_light, 90%);
+      box-shadow: inset 0 0 1px $gray_lighter;
       color: $black;
     }
 
@@ -312,7 +312,7 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
       font-size: 14px;
 
       &:hover {
-        color: darken($blue_light, 10%);
+        color: $blue;
       }
 
       .text-expand {
@@ -333,7 +333,7 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
 
     &:disabled, &:disabled:hover {
       background: $gray_lighter;
-      color: #000;
+      color: $black;
     }
     &:hover {
       background-color: $blue_light;

--- a/regulations/static/regulations/css/scss/module/comment-review.scss
+++ b/regulations/static/regulations/css/scss/module/comment-review.scss
@@ -189,7 +189,7 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
       font-size: 14px;
       line-height: 18px;
       padding: 8px 15px;
-      box-shadow: inset 0 0 1px fade($gray_light, 90%);
+      box-shadow: inset 0 0 1px $gray_lighter;
       border-radius: 2px;
       cursor: pointer;
 

--- a/regulations/static/regulations/css/scss/module/comment-review.scss
+++ b/regulations/static/regulations/css/scss/module/comment-review.scss
@@ -80,14 +80,14 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
   }
 
   .edit-comment {
-    color: $link_blue;
+    color: $blue_light;
     cursor: pointer;
     position: absolute;
     right: 2%;
     top: 0;
 
     .write-icon {
-      fill: $link_blue;
+      fill: $blue_light;
     }
 
     span:hover {
@@ -102,7 +102,7 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
     max-width: 100%;
 
     ul {
-      background: $grey;
+      background: $gray_lighter;
       padding: 0;
       margin: 5px 0 0 0;
     }
@@ -130,12 +130,12 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
   }
 
   .download-comment {
-    background: $blue_light;
+    background: $blue_lightest;
     border-top: 1px solid $text_area_border;
     padding: 10px 15px;
 
     h4 {
-      color: $pacific;
+      color: $blue_light;
       margin: 0;
       float: left;
       font-size: 18px;
@@ -150,7 +150,7 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
     }
 
     .details {
-      color: $dark_text;
+      color: $gray_darker;
       float: right;
       font-size: 14px;
       text-align: right;
@@ -185,19 +185,19 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
     a.btn-group-item {
       color: $black;
       display: inline-block;
-      background: $grey;
+      background: $gray_lighter;
       font-size: 14px;
       line-height: 18px;
       padding: 8px 15px;
-      box-shadow: inset 0 0 1px fade($dark_gray, 90%);
+      box-shadow: inset 0 0 1px fade($gray_light, 90%);
       border-radius: 2px;
       cursor: pointer;
 
       &:hover {
-        background: darken($grey, 10%);
+        background: darken($gray_lighter, 10%);
       }
       &:active, &.current {
-        background: darken($grey, 20%);
+        background: darken($gray_lighter, 20%);
       }
     }
 
@@ -245,7 +245,7 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
       height: auto;
       border-radius: 3px;
       border: 1px solid rgba(0,0,0,.25);
-      box-shadow: inset 0 0 1px fade($dark_gray, 90%);
+      box-shadow: inset 0 0 1px fade($gray_light, 90%);
       color: $black;
     }
 
@@ -254,7 +254,7 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
     }
 
     span {
-      color: $diff_gray;
+      color: $gray_light;
     }
 
     fieldset {
@@ -283,7 +283,7 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
     max-width: 620px;
 
     .required {
-      color: $red_orange;
+      color: $red;
       margin-left: 5px;
     }
 
@@ -307,12 +307,12 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
 
     .show-more-toggle {
       display: inline;
-      color: $link_blue;
+      color: $blue_light;
       cursor: pointer;
       font-size: 14px;
 
       &:hover {
-        color: darken($link_blue, 10%);
+        color: darken($blue_light, 10%);
       }
 
       .text-expand {
@@ -323,7 +323,7 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
   }
 
   .submit-button {
-    background: $pacific;
+    background: $blue_light;
     border-radius: 3px;
     color: #FFF;
     font-size: 17px;
@@ -332,11 +332,11 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
     padding: 12px 30px;
 
     &:disabled, &:disabled:hover {
-      background: $grey;
+      background: $gray_lighter;
       color: #000;
     }
     &:hover {
-      background-color: $pacific_hover;
+      background-color: $blue_light;
     }
   }
 }

--- a/regulations/static/regulations/css/scss/module/comment.scss
+++ b/regulations/static/regulations/css/scss/module/comment.scss
@@ -258,7 +258,7 @@ Write Mode
     transition: .1s;
 
     &:hover {
-      background-color: darken($blue_light, 10%);
+      background-color: $blue;
     }
   }
 
@@ -283,7 +283,7 @@ Write Mode
     padding: 8px 20px;
 
     &:hover {
-      background-color: darken($gray_lighter, 10%);
+      background-color: $gray_light;
     }
   }
 
@@ -433,7 +433,7 @@ Write Mode
       width: 40px;
 
       a:focus .fa {
-        color: darken($black, 10%);
+        color: $black_dark;
         display: inline-block;
       }
 
@@ -444,7 +444,7 @@ Write Mode
         color: $gray_darker;
 
         &:hover {
-          color: darken($black, 10%);
+          color: $black_dark;
         }
       }
     }

--- a/regulations/static/regulations/css/scss/module/comment.scss
+++ b/regulations/static/regulations/css/scss/module/comment.scss
@@ -18,7 +18,7 @@ N&C Header - including Read/Write tab
 
   .tab-descriptions {
     font-size: 14px;
-    color: $dark_field;
+    color: $gray_darker;
     padding: 0 5px;
   }
 
@@ -32,8 +32,8 @@ N&C Header - including Read/Write tab
 
   .read-proposal,
   .write-comment {
-    border-left: 1px solid $medium_gray;
-    color: $dark_text;
+    border-left: 1px solid $gray_light;
+    color: $gray_darker;
     cursor: pointer;
     display: inline-block;
     @include sans-font-regular;
@@ -44,7 +44,7 @@ N&C Header - including Read/Write tab
     width: 245px;
 
     a {
-      color: $navigation_gray;
+      color: $gray_darker;
       padding-left: 5px;
     }
 
@@ -52,7 +52,7 @@ N&C Header - including Read/Write tab
     .write-icon {
       padding: 0;
       font-size: 14px;
-      fill: $navigation_gray;
+      fill: $gray_darker;
     }
 
     &.active-mode a {
@@ -106,7 +106,7 @@ Write Mode
 
       .comment-header-link a {
         color: $black;
-        border-bottom: 2px solid $link_blue;
+        border-bottom: 2px solid $blue_light;
       }
     }
 
@@ -120,16 +120,16 @@ Write Mode
 
     // Show toggle box
     a.comment-context-toggle {
-      background-color: $light_gray;
+      background-color: $gray_lightest;
       border-radius: 2px;
-      color: $dark_text;
+      color: $gray_darker;
       cursor: pointer;
       display: block;
       font-size: 16px;
       padding: 10px 15px;
 
       .comment-context-text {
-        color: $link_blue;
+        color: $blue_light;
       }
 
       .fa-minus-circle,
@@ -193,8 +193,8 @@ Write Mode
       .ProseMirror-menubar {
         min-height: 28px;
         padding: 3px 6px;
-        color: $dark_field;
-        border-bottom: 1px solid $light_field;
+        color: $gray_darker;
+        border-bottom: 1px solid $gray_light;
       }
 
       .comment-content,
@@ -243,7 +243,7 @@ Write Mode
 
   .comment-button,
   a.comment-index-review {
-    background-color: $link_blue;
+    background-color: $blue_light;
     border-radius: 2px;
     color: $white;
     @include sans-font-regular;
@@ -258,7 +258,7 @@ Write Mode
     transition: .1s;
 
     &:hover {
-      background-color: darken($link_blue, 10%);
+      background-color: darken($blue_light, 10%);
     }
   }
 
@@ -272,7 +272,7 @@ Write Mode
   }
 
   .comment-upload-button {
-    background-color: $grey;
+    background-color: $gray_lighter;
     color: $black;
     cursor: pointer;
     border-radius: 2px;
@@ -283,7 +283,7 @@ Write Mode
     padding: 8px 20px;
 
     &:hover {
-      background-color: darken($grey, 10%);
+      background-color: darken($gray_lighter, 10%);
     }
   }
 
@@ -297,7 +297,7 @@ Write Mode
 
   .comment-attachment-count,
   .comment-attachment-limit {
-    color: $citation_gray;
+    color: $gray_dark;
   }
 
   .comment-upload-button {
@@ -315,7 +315,7 @@ Write Mode
   }
 
   .comment-attachment {
-    background: $grey;
+    background: $gray_lighter;
     padding: 3px 10px;
     margin: 5px 5px 0 0;
     word-break: break-all;
@@ -330,7 +330,7 @@ Write Mode
 
     .attachment-remove {
       padding-left: 9px;
-      color: $gray_80;
+      color: $gray;
 
       &:hover {
         color: $black;
@@ -344,7 +344,7 @@ Write Mode
   }
 
   .comment-delete-response {
-    color: $uswds_dark_red;
+    color: $red;
     display: block;
     @include sans-font-bold;
     float: right;
@@ -359,7 +359,7 @@ Write Mode
 
   $icon_width: 48px;
   .write-warning {
-    background-color: $toc_highlight;
+    background-color: $blue_lightest;
     padding: $icon_width/2 $icon_width/4 $icon_width/4 2*$icon_width;
     margin: $icon_width/2 0;
 
@@ -415,7 +415,7 @@ Write Mode
   }
 
   li {
-    background: $gray;
+    background: $gray_light;
     color: $black;
     cursor: default;
     font-weight: 500;
@@ -441,7 +441,7 @@ Write Mode
         vertical-align: middle;
         display: none;
         margin-left: 5px;
-        color: $dark_field;
+        color: $gray_darker;
 
         &:hover {
           color: darken($black, 10%);

--- a/regulations/static/regulations/css/scss/module/diffs.scss
+++ b/regulations/static/regulations/css/scss/module/diffs.scss
@@ -6,22 +6,22 @@
 
 
 del {
-    color: $diff_gray;
+    color: $gray_dark;
     text-decoration: line-through;
 
     img {
-        border: 2px solid $red_orange_50;
+        border: 2px solid $red_lightest;
         opacity: .7;
     }
 }
 
 ins {
-    background-color: $green_light;
+    background-color: $green_lightest;
     text-decoration: none;
     font-style: italic;
 
     .key-term {
-        background-color: $green_light;
+        background-color: $green_lightest;
         text-decoration: none;
         @include serif-font-italic;
 
@@ -32,7 +32,7 @@ ins {
     }
 
     img {
-        border: 2px solid $green_light;
+        border: 2px solid $green_lightest;
     }
 }
 

--- a/regulations/static/regulations/css/scss/module/drawer-content.scss
+++ b/regulations/static/regulations/css/scss/module/drawer-content.scss
@@ -28,14 +28,14 @@ This contains all of the styles specific to the TOC
     }
 
     .toc-entry-at-1, .toc-entry-at-1:hover {
-      border-top: 1px solid $light_field;
+      border-top: 1px solid $gray_light;
       @include sans-font-bold;
       margin-left: -100px;
       padding: 9px 0 9px 110px;
     }
 
     .toc-depth-2 {
-      border-top: 1px solid $light_field;
+      border-top: 1px solid $gray_light;
       margin-left: -100px;
       padding: 0 0 0 105px;
 
@@ -104,7 +104,7 @@ This contains all of the styles specific to the TOC
 
   a:link,
   a:visited {
-    color: $navigation_gray;
+    color: $gray_darker;
     @include border-bottom-light ($width: 1px);
   }
 
@@ -114,7 +114,7 @@ This contains all of the styles specific to the TOC
     margin-left: -100px;
     padding-left: 105px;
     color: $black;
-    background-color: $toc_highlight;
+    background-color: $blue_lightest;
   }
 
   /*
@@ -128,15 +128,15 @@ This contains all of the styles specific to the TOC
   .added a,
   .added a:link,
   .added a:visited {
-      border-right: 8px solid $green_midtone;
+      border-right: 8px solid $green_light;
   }
 
   .deleted a,
   .deleted a:link,
   .deleted a:visited {
-      border-right: 8px solid $red_orange_80;
+      border-right: 8px solid $red_light;
       text-decoration: line-through;
-      color: $gray_80;
+      color: $gray;
   }
 }
 
@@ -155,7 +155,7 @@ This contains all of the styles specific to the TOC
     padding: 10px 0 10px 105px;
     display: block;
     line-height: 1.4;
-    background-color: #F8F8F8;
+    background-color: $gray_lightest;
     @include border-bottom-light ($width: 1px);
     @include regulation-nav-subpart-heading-font;
 }
@@ -187,17 +187,17 @@ This contains all of the styles specific to the history
     .effective-label {
         padding: 0 15px;
         @include sans-font-regular;
-        color: $dark_text;
+        color: $gray_darker;
     }
 
     /*TODO: unify link styles with TOC*/
 
     .version-list {
-        border-top: 1px solid $light_field;
+        border-top: 1px solid $gray_light;
     }
 
     .status-list {
-        border-bottom: 1px solid $light_field;
+        border-bottom: 1px solid $gray_light;
     }
 
     .version-link {
@@ -213,16 +213,16 @@ This contains all of the styles specific to the history
     .current {
         .version-link {
             padding: 10px 15px 0px 15px;
-            background: $toc_highlight;
+            background: $blue_lightest;
         }
 
         .timeline-content-wrap {
-            background: $toc_highlight;
+            background: $blue_lightest;
         }
 
         .rule-list {
             display: block;
-            background: $toc_highlight;
+            background: $blue_lightest;
         }
     }
 
@@ -239,7 +239,7 @@ This contains all of the styles specific to the history
     .version-link:target,
     .current {
         color: $black;
-        background: $toc_highlight;
+        background: $blue_lightest;
         display: block;
     }
 
@@ -268,7 +268,7 @@ This contains all of the styles specific to the history
     }
 
     .rule-status {
-        color: $dark_text;
+        color: $gray_darker;
         text-transform: lowercase;
         @include sans-font-regular;
         display: block;
@@ -319,9 +319,9 @@ This contains all of the styles specific to the history
         margin: 15px;
         background-color: #fff;
         line-height: 32px;
-        border-top: 1px solid $light_field;
-        border-bottom: 1px solid $light_field;
-        border-left: 1px solid $light_field;
+        border-top: 1px solid $gray_light;
+        border-bottom: 1px solid $gray_light;
+        border-left: 1px solid $gray_light;
    }
 
    input[type=text]{
@@ -352,7 +352,7 @@ This contains all of the styles specific to the history
     #history {
         li:hover,
         li.current {
-            background-color: $toc_highlight;
+            background-color: $blue_lightest;
         }
     }
 }
@@ -370,20 +370,20 @@ This contains all of the styles specific to the history
     -webkit-border-radius: 3px;
     border-radius: 3px;
     margin: 15px;
-    background-color: $red_orange;
+    background-color: $red;
     padding: 10px;
     text-align: center;
 }
 
 .stop-button:link,
 .stop-button:visited {
-    color: #fff;
+    color: $white;
 }
 
 .stop-button:hover,
 .stop-button:active,
 .stop-button:focus {
-    background-color: $red_orange_50;
+    background-color: $red_lightest;
     color: $black;
 }
 
@@ -401,7 +401,7 @@ This contains all of the styles specific to the search
     }
 
     h3 {
-        color: $dark_text;
+        color: $gray_darker;
         @include sans-font-regular;
         font-size: 0.875em;
         line-height: normal;
@@ -410,12 +410,12 @@ This contains all of the styles specific to the search
     }
 
     .version-search {
-        border-bottom: 2px solid $medium_gray;
+        border-bottom: 2px solid $gray_light;
         padding: 0 15px 20px 15px;
     }
 
     .search-box {
-        border-bottom: 1px solid $medium_gray;
+        border-bottom: 1px solid $gray_light;
         padding: 20px 15px;
     }
 
@@ -439,9 +439,9 @@ This contains all of the styles specific to the search
     input[type=text]{
         padding: 0 10px;
         text-align: left;
-        border-top: 1px solid $light_field;
+        border-top: 1px solid $gray_light;
         border-right: none;
-        border-bottom: 1px solid $light_field;
-        border-left: 1px solid $light_field;
+        border-bottom: 1px solid $gray_light;
+        border-left: 1px solid $gray_light;
     }
 }

--- a/regulations/static/regulations/css/scss/module/drawer.scss
+++ b/regulations/static/regulations/css/scss/module/drawer.scss
@@ -11,20 +11,20 @@ Universal drawer styles
 --------------------- */
 
 .panel {
-    background-color: $light_gray;
-    border-right: 2px solid $dark_gray;
+    background-color: $gray_lightest;
+    border-right: 2px solid $gray_light;
     @include sans-font-regular;
     font-size: 1em;
     overflow-y: scroll; /* allow content to be scrollable */
 }
 
 .toc-head {
-  border-right: 2px solid $dark_gray;
+  border-right: 2px solid $gray_light;
   transition: 0.1s;
 
   a:link,
   a:visited {
-    color: $navigation_gray;
+    color: $gray_darker;
     text-decoration: none;
     height: 33px;
   }
@@ -62,8 +62,8 @@ Panel Header
 
   position: fixed;
   background-color: $white;
-  border-right: 2px solid $dark_gray;
-  border-bottom: 1px solid $dark_gray;
+  border-right: 2px solid $gray_light;
+  border-bottom: 1px solid $gray_light;
 
   .toc-type, .toc-subheader {
     position: relative;
@@ -119,7 +119,7 @@ Panel Slide Button
     }
 
     .close & {
-        border-bottom: 1px solid $medium_gray;
+        border-bottom: 1px solid $gray_light;
 
         .lt-ie8 &,
          html.no-fontface & {
@@ -161,8 +161,8 @@ currently these are TOC, History, and Search
     margin: 0;
     width: 56px;
     text-align: center;
-    background-color: $light_gray;
-    color: $navigation_gray;
+    background-color: $gray_lightest;
+    color: $gray_darker;
 
     &.current {
         background-color: $white;
@@ -200,7 +200,7 @@ currently these are TOC, History, and Search
       }
 
       .toc-nav-link:hover {
-          background-color: $light_field;
+          background-color: $gray_light;
           border-bottom: none;
       }
 }
@@ -223,7 +223,7 @@ currently these are TOC, History, and Search
         position: absolute;
         width: $closed_drawer_width;
         top: 33px;
-        border-top: 1px solid $medium_gray;
+        border-top: 1px solid $gray_light;
         right: 0;
         left: 198px;
     }
@@ -233,13 +233,13 @@ currently these are TOC, History, and Search
     display: inline-block;
     zoom: 1;
     margin-left: -4px;
-    border-right: 1px solid $medium_gray;
-    border-left: 1px solid $medium_gray;
+    border-right: 1px solid $gray_light;
+    border-left: 1px solid $gray_light;
 
     .close & {
         margin-left: 0;
         display: list-item;
-        border-bottom: 1px solid $medium_gray;
+        border-bottom: 1px solid $gray_light;
         border-right: none;
     }
 }

--- a/regulations/static/regulations/css/scss/module/error.scss
+++ b/regulations/static/regulations/css/scss/module/error.scss
@@ -22,7 +22,7 @@ error.scss contains styles for the generic 404, history 404, and 500 pages
     .cf-icon-table-of-contents,
     .cf-icon-history,
     .cf-icon-search {
-        color: $dark_gray;
+        color: $gray_light;
         margin-right: 10px;
     }
 

--- a/regulations/static/regulations/css/scss/module/expandables.scss
+++ b/regulations/static/regulations/css/scss/module/expandables.scss
@@ -1,5 +1,5 @@
 .expand-button {
-    color: $pacific;
+    color: $blue_light;
     @include sans-font-bold;
     display: inline-block;
     text-transform: uppercase;

--- a/regulations/static/regulations/css/scss/module/extract.scss
+++ b/regulations/static/regulations/css/scss/module/extract.scss
@@ -1,5 +1,5 @@
 .extract {
-    background-color: $bg_gray;
+    background-color: $gray_lightest;
     padding: 0.125em .625em;
     margin-bottom: 1em;
     border-bottom: 0px;

--- a/regulations/static/regulations/css/scss/module/footer.scss
+++ b/regulations/static/regulations/css/scss/module/footer.scss
@@ -7,7 +7,7 @@ Global Footer
     padding: 15px;
     margin-left: 285px;
     @include sans-font-regular;
-    color: $dark_text;
+    color: $gray_darker;
 
     abbr[title] {
         border-bottom: none;
@@ -88,14 +88,14 @@ Next/Previous Links
 
 /* styles for both the next and previous blocks */
 .next-prev {
-    border-top: 2px solid $medium_gray;
+    border-top: 2px solid $gray_light;
     width: 45%;
     @include sans-font-bold;
 }
 
 .pager {
     @include sans-font-regular;
-    color: $dark_text;
+    color: $gray_darker;
     text-align: center;
 }
 
@@ -138,7 +138,7 @@ Link Styles
 
 .next-prev-link:link,
 .next-prev-link:visited {
-    color: $link_blue;
+    color: $blue_light;
     text-decoration: none;
 }
 

--- a/regulations/static/regulations/css/scss/module/forms.scss
+++ b/regulations/static/regulations/css/scss/module/forms.scss
@@ -19,8 +19,8 @@ button {
     height: 32px;
     vertical-align: bottom;
     margin: 0;
-    background-color: $pacific;
-    color: #fff;
+    background-color: $blue_light;
+    color: $white;
     border: none;
     vertical-align: bottom;
     text-align: center;
@@ -31,12 +31,12 @@ button {
 
 button:hover,
 button:active {
-    background-color: $pacific_hover;
+    background-color: $blue_light;
 }
 
 textarea:focus,
 input:focus {
-    border: 1px solid $pacific;
+    border: 1px solid $blue_light;
 }
 
 .file-upload {
@@ -69,7 +69,7 @@ Selects
     position: relative;
     background: white url('../img/select.png') no-repeat bottom right;
     //width: 100%;
-    border: solid 1px $light_field;
+    border: solid 1px $gray_light;
     height: 32px;
 }
 
@@ -90,7 +90,7 @@ select {
     border: none;
     box-shadow: none;
     padding: 0 10px; /* add padding to the select, not the div */
-    color: $dark_text;
+    color: $gray_darker;
     height: 32px;
 }
 

--- a/regulations/static/regulations/css/scss/module/header.scss
+++ b/regulations/static/regulations/css/scss/module/header.scss
@@ -4,7 +4,7 @@
 
 .reg-header {
     width: 100%;
-    color: $dark_field;
+    color: $gray_darker;
     @include sans-font-regular;
     position: absolute;
     height: $mainhead_height + $subhead_height;
@@ -22,7 +22,7 @@
 
 .main-head {
     border-bottom: 2px solid $blue;
-    background: #fff;
+    background: $white;
     position: fixed;
     top: 0;
     width: 100%;
@@ -86,7 +86,7 @@
             content: "|";
             @include sans-font-regular;
             padding: 0 12px;
-            color: $medium_gray;
+            color: $gray_light;
         }
     }
 }
@@ -107,14 +107,14 @@
     position: fixed;
     top: $mainhead_height;
     min-width: 100%;
-    background: $light_gray;
+    background: $gray_lightest;
     color: $black;
     line-height: 35px;
     height: 2.125em;
     @include border-bottom-medium($width: 1px);
     z-index: 200;
     .main {
-        border-right: 1px solid $medium_gray;
+        border-right: 1px solid $gray_dark;
     }
 }
 
@@ -133,7 +133,7 @@
     .with-subpart:before {
         content: "|";
         @include sans-font-regular;
-        color: $dark_gray;
+        color: $gray_light;
         display: inline-block;
         margin: 0 10px;
     }
@@ -239,12 +239,12 @@ BIG SCREENS
         margin: 0 0 0 24px;
 
         a {
-          color: $dark_field;
+          color: $gray_darker;
           padding: 0;
         }
 
         &:last-child {
-          border-bottom: 2px solid $dark_gray;
+          border-bottom: 2px solid $gray_dark;
         }
 
         .logo {
@@ -315,12 +315,12 @@ tiny screens
         position: fixed;
         top: 60px;
         width: 100%;
-        background: $bg_gray;
+        background: $gray_lightest;
         z-index: 999999;
     }
 
     .app-nav-list-item {
-        border-bottom: 1px solid $dark_gray;
+        border-bottom: 1px solid $gray_light;
         z-index: 999999;
 
         a {
@@ -332,7 +332,7 @@ tiny screens
         a:hover,
         a:active,
         a:focus {
-            background: #E6E6E6;
+            background: $gray_lighter;
         }
     }
 
@@ -347,7 +347,7 @@ tiny screens
     .mobile-nav-trigger:active,
     .mobile-nav-trigger:focus,
     .mobile-nav-trigger.open {
-        background-color: $bg_gray;
+        background-color: $gray_lightest;
     }
 
     .title {

--- a/regulations/static/regulations/css/scss/module/header.scss
+++ b/regulations/static/regulations/css/scss/module/header.scss
@@ -45,7 +45,7 @@
 
       &:hover,
       &:active {
-        color: darken($blue, 10%);
+        color: $blue_dark;
       }
     }
 
@@ -100,7 +100,7 @@
 
 .title a:hover,
 .title a:active {
-    color: darken($blue, 10%);
+    color: $blue_dark;
 }
 
 .sub-head {
@@ -193,7 +193,7 @@ Application Nav
   &:hover,
   &:active,
   &:focus {
-    color: darken($blue, 10%);;
+    color: $blue_dark;
   }
 }
 

--- a/regulations/static/regulations/css/scss/module/interpretations.scss
+++ b/regulations/static/regulations/css/scss/module/interpretations.scss
@@ -1,5 +1,5 @@
 .inline-interpretation {
-    background-color: $bg_gray;
+    background-color: $gray_lightest;
     padding: 0.125em .625em;
     margin-bottom: 1em;
     margin-left: -20px; /*aligns with list marker */
@@ -7,12 +7,12 @@
     position: relative;
 
     &:hover {
-        background-color: $grey;
+        background-color: $gray_lighter;
         cursor: pointer;
     }
 
     &.open {
-        background-color: $grey;
+        background-color: $gray_lighter;
         cursor: auto;
     }
 
@@ -28,7 +28,7 @@
     }
 
     .expand-button {
-        color: $pacific;
+        color: $blue_light;
         @include sans-font-bold;
         position: absolute;
         display: inline-block;
@@ -156,7 +156,7 @@
 
     &:hover {
         cursor: default;
-        background-color: $bg_gray;
+        background-color: $gray_lightest;
     }
 }
 

--- a/regulations/static/regulations/css/scss/module/navigation.scss
+++ b/regulations/static/regulations/css/scss/module/navigation.scss
@@ -39,7 +39,7 @@ Appendix Navigation
 .appendix-nav a:visited {
     color: #101820;
     text-decoration: none;
-    border-bottom: 1px solid $link_blue;
+    border-bottom: 1px solid $blue_light;
 }
 
 .appendix-nav a:hover,

--- a/regulations/static/regulations/css/scss/module/no-js.scss
+++ b/regulations/static/regulations/css/scss/module/no-js.scss
@@ -22,7 +22,7 @@
     }
 
     .inline-interpretation {
-        background-color: $grey;
+        background-color: $gray_lighter;
         pointer-events: none;
         cursor: default;
     }

--- a/regulations/static/regulations/css/scss/module/note.scss
+++ b/regulations/static/regulations/css/scss/module/note.scss
@@ -1,5 +1,5 @@
 .note {
-    background-color: $bg_gray;
+    background-color: $gray_lightest;
     padding: 1em;
     padding-left: -40px; /* 40px is the amount of indentation per ol level
                             This makes notes look flush with their parent */
@@ -8,13 +8,13 @@
     }
 }
 .footnote-box {
-    background-color: $bg_gray;
+    background-color: $gray_lightest;
     padding: 1.5em;
     margin-left: 20px;
 
     h5 {
       margin-top: 0;
-      color: $dark_text;
+      color: $gray_darker;
       @include sans-font-bold;
     }
 

--- a/regulations/static/regulations/css/scss/module/reg-landing.scss
+++ b/regulations/static/regulations/css/scss/module/reg-landing.scss
@@ -52,7 +52,7 @@ reg-landing.scss contains styles specific to the regulation landing page
     padding-top: 2em;
     height: 1px;
     display: block;
-    border-bottom: 1px solid $light_field;
+    border-bottom: 1px solid $gray_light;
     content: '';
 }
 
@@ -185,6 +185,6 @@ Small screens
 
     .secondary-content .landing-sidebar .alert {
         margin-top: 0;
-        border-top: 1px solid $light_field;
+        border-top: 1px solid $gray_light;
     }
 }

--- a/regulations/static/regulations/css/scss/module/search-results.scss
+++ b/regulations/static/regulations/css/scss/module/search-results.scss
@@ -14,7 +14,7 @@ h2.search-term {
 }
 
 p.search-version {
-    color: $dark_gray;
+    color: $gray_light;
     text-transform: uppercase;
     @include sans-font-bold;
     font-size: 0.875em;
@@ -47,7 +47,7 @@ p.search-version {
     }
     
     .internal {
-        color: $link_blue;
+        color: $blue_light;
     }
 }
 
@@ -58,13 +58,13 @@ p.search-version {
     a:link,
     a:visited {
         @include sans-font-bold;
-        color: $pacific;
+        color: $blue_light;
         text-decoration: none;
     }
 
     a:hover,
     a:active {
-        border-bottom: 1px solid $pacific;
+        border-bottom: 1px solid $blue_light;
     }
 
     .next {

--- a/regulations/static/regulations/css/scss/module/sidebar.scss
+++ b/regulations/static/regulations/css/scss/module/sidebar.scss
@@ -41,11 +41,11 @@ Headers within the sidebar should be <h4>
         margin: 0;
         text-transform: uppercase;
         letter-spacing: 1px;
-        color: $mid_text;
+        color: $gray_darkest;
         @include sans-font-bold;
 
         &.important {
-            color: $red_orange;
+            color: $red;
         }
 
         h5 {
@@ -61,11 +61,11 @@ Sidebar Expandables
 
     .expandable {
         cursor: pointer;
-        background-color: $bg_gray;
+        background-color: $gray_lightest;
         width: 100%;
 
         &.has-content {
-            background-color: $light_orange;
+            background-color: $orange_lightest;
         }
 
         h4 {
@@ -84,13 +84,13 @@ Sidebar Expandables
         &.expandable a:before {
             @extend .cf-icon;
             content: "\e109";
-            color: $pacific;
+            color: $blue_light;
         }
 
         &.open a:before {
             @extend .cf-icon;
             content: "\e111";
-            color: $pacific;
+            color: $blue_light;
         }
     }
 
@@ -100,7 +100,7 @@ Sidebar Expandables
     */
 
     .sidebar-subsection {
-        border-bottom: 1px solid $light_neutral;
+        border-bottom: 1px solid $gray_light;
         padding-bottom: 28px;
         padding-top: 28px;
     }
@@ -122,10 +122,10 @@ Sidebar Headers
 */
 .sidebar-header {
     @extend .group;
-    background-color: $bg_gray;
+    background-color: $gray_lightest;
 
     h4 {
-        color: $dark_gray;
+        color: $gray_light;
         padding: .5em 0 .5em .9375em;
         @include sans-font-bold;
         text-transform: uppercase;
@@ -142,7 +142,7 @@ Sidebar Headers
     }
 
     &.spinner {
-        background: $bg_gray url(../img/blue_spinner.gif) no-repeat center right;
+        background: $gray_lightest url(../img/blue_spinner.gif) no-repeat center right;
         background-position-x: 92%;
     }
 
@@ -150,12 +150,12 @@ Sidebar Headers
     (-webkit-min-device-pixel-ratio: 2),
     (min-resolution: 192dpi) {
         .close-button {
-            background: $bg_gray url(../img/close@2x.png) no-repeat 0 0;
+            background: $gray_lightest url(../img/close@2x.png) no-repeat 0 0;
             background-size: 13px 13px;
         }
 
         &.spinner {
-            background: $bg_gray url(../img/blue_spinner@2x.gif) no-repeat center right;
+            background: $gray_lightest url(../img/blue_spinner@2x.gif) no-repeat center right;
             background-position-x: 92%;
             background-size: 19px 19px;
         }
@@ -193,13 +193,13 @@ Regs Meta contains the sub-content meta data found in the sidebar
     }
 
     .explanation {
-        color: $dark_gray;
+        color: $gray_light;
         margin: 0;
     }
 
     .divided-list {
         margin-top: 12px;
-        border-top: 1px solid $light_neutral;
+        border-top: 1px solid $gray_light;
 
         li {
             display: block;
@@ -228,15 +228,15 @@ Regs Meta contains the sub-content meta data found in the sidebar
             float: right;
             font-size: 0.875em;
             line-height: 2;
-            color: $dark_gray;
+            color: $gray_light;
         }
 
         &:hover, &:active {
             text-decoration: none;
-            color: $pacific;
+            color: $blue_light;
 
             .cf-icon-right {
-                color: $pacific;
+                color: $blue_light;
             }
         }
     }
@@ -289,7 +289,7 @@ When open definitions appear in the right sidebar
     }
 
     .open-definition {
-        border-bottom: 1px solid $medium_gray;
+        border-bottom: 1px solid $gray_light;
     }
 
     .definition-text,
@@ -304,13 +304,13 @@ When open definitions appear in the right sidebar
         &.inactive,
         &.inactive a.continue-link.internal,
         &.inactive a.citation.definition {
-            color: $gray_80;
+            color: $gray;
         }
     }
 
     .definition-warning {
-        color: $red_orange;
-        border-bottom: 1px solid $light_field;
+        color: $red;
+        border-bottom: 1px solid $gray_light;
         margin: 0 1em;
         padding: 1em 0 0 0;
 
@@ -328,7 +328,7 @@ When open definitions appear in the right sidebar
     .msg {
         width: 85%;
         float: left;
-        border-bottom: 1px solid $light_field;
+        border-bottom: 1px solid $gray_dark;
         padding-bottom: 1em;
     }
 
@@ -375,7 +375,7 @@ Styles for the UI help slide down
 
     li {
         margin-top: 15px;
-        color: $mid_text;
+        color: $gray_darkest;
     }
 
     .cf-icon-right {
@@ -383,13 +383,13 @@ Styles for the UI help slide down
     }
 
     .modified {
-        border-right: 8px solid $green_midtone;
+        border-right: 8px solid $green_light;
     }
 
     .deleted {
-        border-right: 8px solid $red_orange_80;
+        border-right: 8px solid $red_light;
         text-decoration: line-through;
-        color: $gray_80;
+        color: $gray;
     }
 
 }
@@ -409,7 +409,7 @@ Styles for the UI help slide down
     padding: 10px;
     margin-right: 15px;
     border-radius: 4px;
-    background-color: $bg_gray;
+    background-color: $gray_lightest;
     text-align: center;
     vertical-align: middle;
 }
@@ -427,13 +427,13 @@ Styles for the UI help slide down
 
 .sample-menu {
     display: block;
-    background: $bg_gray;
+    background: $gray_lightest;
     padding: 15px;
-    border-bottom: 1px solid $medium_gray;
+    border-bottom: 1px solid $gray_light;
 }
 
 .sample-menu:first-child {
-    border-top: 1px solid $medium_gray;
+    border-top: 1px solid $gray_light;
 }
 
 /*
@@ -477,7 +477,7 @@ Small screens
     }
 
     .regs-meta {
-        border-top: 1px solid $light_neutral;
+        border-top: 1px solid $gray_light;
     }
 
     /*
@@ -493,7 +493,7 @@ Small screens
         min-width: 100%;
         min-height: 200px;
         padding: 0 20px 80px 50px;
-        background: $bg_gray;
+        background: $gray_lightest;
         @include border-top-light($width: 2px);
         z-index: 200;
         overflow-y: scroll;
@@ -515,7 +515,7 @@ Small screens
     }
 
     .sidebar-header {
-        background-color: $bg_gray;
+        background-color: $gray_lightest;
     }
 }
 

--- a/regulations/static/regulations/css/scss/module/sxs.scss
+++ b/regulations/static/regulations/css/scss/module/sxs.scss
@@ -24,7 +24,7 @@ SxS window
     width: 100%;
     height: 100%;
     min-height: 100%;
-    background: #fff;
+    background: $white;
     z-index: 9999;
     overflow-y: auto;
     padding-bottom: 120px; //offset persistent header for scroll
@@ -46,7 +46,7 @@ SxS header
     top: 60px;
     width: 100%;
     height: 2.125em;
-    background-color: $light_orange;
+    background-color: $orange_lightest;
     border-bottom: 1px solid $orange;
     z-index: 100;
 
@@ -77,9 +77,9 @@ Back link
     display: inline-block;
     padding: 0 15px;
     min-width: 5em;
-    background-color: $bg_gray;
-    color: $dark_gray;
-    border-right: 2px solid $medium_gray;
+    background-color: $gray_lightest;
+    color: $gray_light;
+    border-right: 2px solid $gray_light;
     text-decoration: none;
     height: 34px;
     line-height: 34px; /* match height of the .sxs-header - 1px */
@@ -93,7 +93,7 @@ Back link
 
 .sxs-back-button:hover,
 .sxs-back-button:active {
-    color: $pacific;
+    color: $blue_light;
 }
 
 
@@ -151,7 +151,7 @@ Metadata info for the SxS Analysis
     h3,
     h4 {
         margin-bottom: 0;
-        color: $dark_gray;
+        color: $gray_light;
         @include sans-font-bold;
     }
 
@@ -190,7 +190,7 @@ Footnotes
 
 .footnote-title {
     margin-top: 2em;
-    color: $dark_text;
+    color: $gray_darker;
 }
 
 .footnotes {
@@ -232,7 +232,7 @@ Footnotes
 
     .highlight {
         .footnote-inner {
-            background-color: $bg_gray;
+            background-color: $gray_lightest;
         }
     }
 }

--- a/regulations/static/regulations/css/scss/module/universal-landing.scss
+++ b/regulations/static/regulations/css/scss/module/universal-landing.scss
@@ -21,7 +21,7 @@
  */
 
 .hero {
-    background-color: $green_midtone;
+    background-color: $green_light;
     overflow: hidden;
     @include sans-font-regular;
     @include border-bottom-light;
@@ -99,7 +99,7 @@
     a:hover,
     a:active,
     a:focus {
-        background-color: $bg_gray;
+        background-color: $gray_lightest;
     }
 
     .title-num {
@@ -127,7 +127,7 @@
         display: block;
         float: right;
         line-height: 60px;
-        color: $pacific;
+        color: $blue_light;
         font-size: 1.25em;
     }
 
@@ -144,7 +144,7 @@
         a {
             display: inline-block;
             float: right;
-            color: $link_blue;
+            color: $blue_light;
             margin: 0;
             padding: 0;
             height: auto;

--- a/regulations/static/regulations/css/scss/print.scss
+++ b/regulations/static/regulations/css/scss/print.scss
@@ -188,7 +188,7 @@ a.definition:visited,
 a.citation:link,
 a.citation:visited {
     border-bottom: none;
-    color: #101820;
+    color: $black;
 }
 
 a[href^="http://"] {
@@ -210,8 +210,8 @@ a[href^="http://"] {
 
 .inline-interpretation {
 
-    background: $bg_gray;
-    border: 1px solid $bg_gray;
+    background: $gray_lightest;
+    border: 1px solid $gray_lightest;
 
      .hidden {
 
@@ -237,7 +237,7 @@ a[href^="http://"] {
     position: relative;
     padding: 0;
     margin: 10px;
-    border: 1px solid $light_neutral;
+    border: 1px solid $gray_light;
 
     .sidebar-header {
         display: none;
@@ -357,7 +357,7 @@ a[href^="http://"] {
 }
 
 .hero {
-    background-color: #ffffff;
+    background-color: $white;
 
     .inner-wrap {
         height: 180px;
@@ -396,7 +396,7 @@ a[href^="http://"] {
 }
 
 .title-hero {
-    background-color: #ffffff;
+    background-color: $white;
 }
 
 

--- a/regulations/static/regulations/css/scss/typography.scss
+++ b/regulations/static/regulations/css/scss/typography.scss
@@ -160,7 +160,7 @@ ol[type="no-marker"] {
 
 a:link,
 a:visited {
-    color: $link_blue;
+    color: $blue_light;
     text-decoration: none;
     border: none;
     -webkit-transition: .1s;
@@ -178,13 +178,13 @@ a:visited {
 .internal:visited {
     color: $black;
     text-decoration: none;
-    border-bottom: 1px solid $link_blue;
+    border-bottom: 1px solid $blue_light;
 }
 
 .internal:hover,
 .internal:active,
 .internal:focus {
-    background-color: #cde3f1;
+    background-color: $blue_lighter;
 }
 
 /*  External Links
@@ -201,7 +201,7 @@ a:visited {
 
 .phone:link,
 .phone:visited {
-    color: $pacific;
+    color: $blue_light;
 }
 
 .phone:before {
@@ -261,23 +261,23 @@ a:visited {
 .definition:visited {
     color: $black;
     text-decoration: none;
-    border-bottom: 1px solid $light_field;
+    border-bottom: 1px solid $gray_light;
 }
 
 .definition:hover,
 .definition:active {
-    border-bottom: 1px solid $medium_gray;
-    background-color: $grey;
+    border-bottom: 1px solid $gray_light;
+    background-color: $gray_lighter;
 }
 
 .definition.active {
-    background-color: $grey;
+    background-color: $gray_lighter;
 }
 
 .inline-interpretation {
     .definition:link,
     .definition:visited {
-         border-bottom: 1px solid $medium_gray;
+         border-bottom: 1px solid $gray_light;
     }
 }
 
@@ -582,7 +582,7 @@ th,
 td {
     padding: 15px;
     line-height: 20px;
-    border: 1px solid $gray_80;
+    border: 1px solid $gray;
 }
 
 th {
@@ -638,7 +638,7 @@ pre {
     margin: 0 auto;
     max-width: 600px;
     padding: 10px;
-    background-color: $bg_gray;
+    background-color: $gray_lightest;
     overflow-x: scroll;
     word-wrap: normal;
     white-space: pre;


### PR DESCRIPTION
Ok this took a bit longer than expected.

All the colors used to run -site have been condensed into a smaller set with a max of 7 variants for any one color family (gray for instance). In addition to re-naming there was some merging of colors. The process for choosing which color should be merged was not entirely scientific but I tried to pick the color that worked best globally out of the 2-3 I was merging. 

<img width="746" alt="screen shot 2016-07-05 at 5 37 56 pm" src="https://cloud.githubusercontent.com/assets/776987/16602110/2f4fa9da-42d7-11e6-860f-c9402d08585c.png">

I mention this because **_visual regression tests will fail_** since colors that used to exist no longer exist. When this is done, a new baseline will be established. We'll want to run the accessibility tests on this before merging into master to make sure everything still has the proper contrast ratios.

If something needs to be a bit darker, we can try switching it from `$gray` to `$gray_dark` but the goal here is to not add additional colors. That's not to say that the colors chosen are set in stone. There may be an instance were we want to redefine what `$gray_dark` is (I think 2 other very slightly different colors got merged into that) because maybe I merged things into the lighter variant when I should have chosen the darker one. We can still change that.

So take a peak and let me know if you think there are sections that didn't survive the merge and should be darker/lighter than the color I chose for them.


#### Chosen colors visualized here for reference. 
![screen shot 2016-07-05 at 5 30 26 pm](https://cloud.githubusercontent.com/assets/776987/16602068/d6fbdd62-42d6-11e6-897c-8b717f383a22.png)
 