### PR TITLE
Add option to drawer to forceOpen on load

### DIFF
--- a/regulations/static/regulations/js/source/app-init.js
+++ b/regulations/static/regulations/js/source/app-init.js
@@ -23,11 +23,13 @@ Backbone.$ = $;
     },
 
     init: function() {
+        var regs = window.regs || {};
+
         Router.start();
         this.bindEvents();
         var gaview = new AnalyticsHandler();
         var header = new HeaderView();  // Header before Drawer as Drawer sends Header events
-        var drawer = new DrawerView();
+        var drawer = new DrawerView({forceOpen: regs.drawer && regs.drawer.forceOpen});
         var main = new MainView();
         var sidebar = new SidebarView();
         setTimeout(function() {

--- a/regulations/static/regulations/js/source/views/drawer/drawer-tabs-view.js
+++ b/regulations/static/regulations/js/source/views/drawer/drawer-tabs-view.js
@@ -22,7 +22,7 @@ var DrawerTabsView = Backbone.View.extend({
         'search': '#search-link'
     },
 
-    initialize: function() {
+    initialize: function(options) {
         this.listenTo(DrawerEvents, 'pane:change', this.changeActiveTab);
         this.listenTo(DrawerEvents, 'pane:init', this.setStartingTab);
         this.$activeEls = $('#menu, #site-header, #content-body, #primary-footer, #content-header');
@@ -36,7 +36,7 @@ var DrawerTabsView = Backbone.View.extend({
 
         // For browser widths above 1100px apply the 'open' class
         //  and set drawer state to open
-        if (document.documentElement.clientWidth > 1100) {
+        if (options.forceOpen || document.documentElement.clientWidth > 1100) {
             this.$toggleArrow.addClass('open');
             this.drawerState = 'open';
         }

--- a/regulations/static/regulations/js/source/views/drawer/drawer-view.js
+++ b/regulations/static/regulations/js/source/views/drawer/drawer-view.js
@@ -12,7 +12,7 @@ Backbone.$ = $;
 var DrawerView = Backbone.View.extend({
     el: '#menu',
 
-    initialize: function() {
+    initialize: function(options) {
         this.listenTo(DrawerEvents, 'pane:change', this.setActivePane);
         this.listenTo(DrawerEvents, 'pane:init', this.setActivePane);
 
@@ -23,7 +23,7 @@ var DrawerView = Backbone.View.extend({
         this.childViews['table-of-contents'] = new TOCView();
         this.childViews['timeline'] = new HistoryView();
         this.childViews['search'] = new SearchView();
-        this.childViews['drawer-tabs'] = new DrawerTabs();
+        this.childViews['drawer-tabs'] = new DrawerTabs({forceOpen: options.forceOpen});
 
         var $tocSecondary = $('#table-of-contents-secondary');
         if ($tocSecondary.length) {

--- a/regulations/static/regulations/js/unittests/specs/views/drawer-tabs-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/drawer-tabs-spec.js
@@ -2,8 +2,6 @@ var chai = require('chai');
 var expect = chai.expect;
 var jsdom = require('mocha-jsdom');
 
-var helpers = require('../spec-helpers');
-
 
 describe('DrawerTabsView', function() {
   jsdom();

--- a/regulations/static/regulations/js/unittests/specs/views/drawer-tabs-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/drawer-tabs-spec.js
@@ -1,0 +1,38 @@
+var chai = require('chai');
+var expect = chai.expect;
+var jsdom = require('mocha-jsdom');
+
+var helpers = require('../spec-helpers');
+
+
+describe('DrawerTabsView', function() {
+  jsdom();
+
+  describe('::initialize', function() {
+    describe('with forceOpen', function() {
+      var $fixture, view;
+
+      beforeEach(function() {
+        var DrawerTabsView = require('../../../source/views/drawer/drawer-tabs-view');
+
+        $fixture = $('<div id="fixutre"></div>');
+        $fixture.append('<div class="toc-head"><a href="#" id="panel-link" class="toc-toggle panel-slide"></a></div>'
+
+        ).appendTo('body');
+
+        view = new DrawerTabsView({forceOpen: true});
+      });
+
+      afterEach(function() {
+        view.remove();
+        $fixture.remove();
+      });
+
+      it('is in the open state', function() {
+        expect(view).to.be.ok;
+        expect(view.drawerState).to.eql('open');
+        expect(view.$toggleArrow.attr('class')).to.match(/\bopen\b/);
+      });
+    });
+  });
+});


### PR DESCRIPTION
In `fec-eregs`, we don't have any landing content for the regulations, so when you go to https://fec-prod-eregs.18f.gov/regulations/4 on smaller screens, it's unclear to the user where to go next. By adding an option to force the drawer open, even on smaller screens, we give the user a clue as to what actions are available.

`fec-eregs` can enable this options by setting `window.regs.drawer.forceOpen = true` before initializing the drawer.

I'm open to other ideas, I couldn't find an obvious way to detect that there's no landing content and condition it based on that.