### PR TITLE
Theme Variables

### DIFF
--- a/regulations/static/regulations/css/scss/_base-variables.scss
+++ b/regulations/static/regulations/css/scss/_base-variables.scss
@@ -46,18 +46,18 @@ $history_drawer_border_color: #d1d3d5;
 
 // Theme Variables
 
-$primary_color: $blue !default; // Site title, Tab label text, Header stroke
-$primary_color_dark: $blue_dark !default; // Darker version of primary color often used for hover states
-$action_color: $blue_light !default; // Links and Buttons
-$action_color_dark: $blue !default; // Darker version of action color often used for hover states
-$panel_background_color: $gray_lightest !default; // Table of contents background, subhead color, drawer color
-$panel_border_color: $gray_light !default; // Colors the borders for panel_color
-$panel_highlight_color: $blue_lightest !default; // Highlight color for table of contents
-$panel_text_color: $gray_darker !default; // Text color for table of contents
-$text_highlight_color: $green_lightest !default; // Text highlight used for diffs
-$success_color: $green_lightest !default; // Used as background for success messages
-$notice_color: $blue_lightest !default; // Used as background for neutral notice messages
-$warning_color: $pink !default; // Used as background for warning messages 
+$primary_color: $blue; // Site title, Tab label text, Header stroke
+$primary_color_dark: $blue_dark; // Darker version of primary color often used for hover states
+$action_color: $blue_light; // Links and Buttons
+$action_color_dark: $blue; // Darker version of action color often used for hover states
+$panel_background_color: $gray_lightest; // Table of contents background, subhead color, drawer color
+$panel_border_color: $gray_light; // Colors the borders for panel_color
+$panel_highlight_color: $blue_lightest; // Highlight color for table of contents
+$panel_text_color: $gray_darker; // Text color for table of contents
+$text_highlight_color: $green_lightest; // Text highlight used for diffs
+$success_color: $green_lightest; // Used as background for success messages
+$notice_color: $blue_lightest; // Used as background for neutral notice messages
+$warning_color: $pink; // Used as background for warning messages
 
 // Type Variables
 $body_font: "Merriweather", Georgia, serif;

--- a/regulations/static/regulations/css/scss/_base-variables.scss
+++ b/regulations/static/regulations/css/scss/_base-variables.scss
@@ -55,6 +55,9 @@ $panel_border_color: $gray_light !default; // Colors the borders for panel_color
 $panel_highlight_color: $blue_lightest !default; // Highlight color for table of contents
 $panel_text_color: $gray_darker !default; // Text color for table of contents
 $text_highlight_color: $green_lightest !default; // Text highlight used for diffs
+$success_color: $green_lightest !default; // Used as background for success messages
+$notice_color: $blue_lightest !default; // Used as background for neutral notice messages
+$warning_color: $pink !default; // Used as background for warning messages 
 
 // Type Variables
 $body_font: "Merriweather", Georgia, serif;

--- a/regulations/static/regulations/css/scss/_base-variables.scss
+++ b/regulations/static/regulations/css/scss/_base-variables.scss
@@ -44,6 +44,18 @@ $orange_lightest: #FFECD1;
 $text_area_border: rgba(0, 0, 0, 0.25);
 $history_drawer_border_color: #d1d3d5;
 
+// Theme Variables
+
+$primary_color: $blue !default; // Site title, Tab label text, Header stroke
+$primary_color_dark: $blue_dark !default; // Darker version of primary color often used for hover states
+$action_color: $blue_light !default; // Links and Buttons
+$action_color_dark: $blue !default; // Darker version of action color often used for hover states
+$panel_background_color: $gray_lightest !default; // Table of contents background, subhead color, drawer color
+$panel_border_color: $gray_light !default; // Colors the borders for panel_color
+$panel_highlight_color: $blue_lightest !default; // Highlight color for table of contents
+$panel_text_color: $gray_darker !default; // Text color for table of contents
+$text_highlight_color: $green_lightest !default; // Text highlight used for diffs
+
 // Type Variables
 $body_font: "Merriweather", Georgia, serif;
 

--- a/regulations/static/regulations/css/scss/_layout.scss
+++ b/regulations/static/regulations/css/scss/_layout.scss
@@ -164,9 +164,9 @@ TOC Header Navigation
   left: 0;
   width: 240px;
   height: 34px;
-  border-right: 2px solid $gray_light;
+  border-right: 2px solid $panel_border_color;
   @include border-bottom-medium($width: 1px);
-  background-color: $gray_lightest;
+  background-color: $panel_background_color;
 }
 
 .header-main {

--- a/regulations/static/regulations/css/scss/_mixins.scss
+++ b/regulations/static/regulations/css/scss/_mixins.scss
@@ -89,27 +89,27 @@ mixins.scss contains any mixins to be used throughout the Sass files
 
 // Border Styles
 @mixin border-bottom-medium($width: 1px) {
-  border-bottom: $width solid $gray_light;
+  border-bottom: $width solid $panel_border_color;
 }
 
 @mixin border-bottom-light($width: 1px) {
-  border-bottom: $width solid $gray_light;
+  border-bottom: $width solid $panel_border_color;
 }
 
 @mixin border-bottom-dark($width: 1px) {
-  border-bottom: $width solid $gray_light;
+  border-bottom: $width solid $panel_border_color;
 }
 
 @mixin border-top-light($width: 1px) {
-  border-top: $width solid $gray_light;
+  border-top: $width solid $panel_border_color;
 }
 
 @mixin border-top-medium($width: 1px) {
-  border-top: $width solid $gray_light;
+  border-top: $width solid $panel_border_color;
 }
 
 @mixin border-right-light($width: 1px) {
-  border-right: $width solid $gray_light;
+  border-right: $width solid $panel_border_color;
 }
 
 // Animations
@@ -131,7 +131,7 @@ mixins.scss contains any mixins to be used throughout the Sass files
   height: 1em;
   margin: 0 auto;
   content: '\e112';
-  color: $blue;
+  color: $primary_color;
   text-align: center;
   font-size: 1.375em;
   margin-top: 2em;

--- a/regulations/static/regulations/css/scss/_typography.scss
+++ b/regulations/static/regulations/css/scss/_typography.scss
@@ -160,7 +160,7 @@ ol[type="no-marker"] {
 
 a:link,
 a:visited {
-  color: $blue_light;
+  color: $action_color;
   text-decoration: none;
   border: none;
   -webkit-transition: 0.1s;
@@ -178,13 +178,13 @@ a:visited {
 .internal:visited {
   color: $black;
   text-decoration: none;
-  border-bottom: 1px solid $blue_light;
+  border-bottom: 1px solid $action_color;
 }
 
 .internal:hover,
 .internal:active,
 .internal:focus {
-  background-color: $blue_lighter;
+  background-color: $action_color_dark;
 }
 
 /*  External Links
@@ -201,7 +201,7 @@ a:visited {
 
 .phone:link,
 .phone:visited {
-  color: $blue_light;
+  color: $action_color;
 }
 
 .phone:before {
@@ -300,17 +300,17 @@ a:visited {
 }
 
 .btn, .btn:link, .btn:visited {
-  background-color: #0072ce;
+  background-color: $action_color;
   color: $white;
 }
 
 .btn.hover, .btn:hover {
-  background-color: #328ed8;
+  background-color: $action_color_dark;
 }
 
 .btn.focus, .btn:focus {
-  background-color: #328ed8;
-  outline: #0072ce dotted 1px;
+  background-color: $action_color_dark;
+  outline: $action_color dotted 1px;
   outline-offset: 1px;
 }
 

--- a/regulations/static/regulations/css/scss/_typography.scss
+++ b/regulations/static/regulations/css/scss/_typography.scss
@@ -184,7 +184,8 @@ a:visited {
 .internal:hover,
 .internal:active,
 .internal:focus {
-  background-color: $action_color_dark;
+  color: $black_dark;
+  border-bottom: 1px solid $action_color_dark;
 }
 
 /*  External Links
@@ -279,39 +280,6 @@ a:visited {
   .definition:visited {
      border-bottom: 1px solid $gray_light;
   }
-}
-
-// button styles
-.btn {
-  @include sans-font-regular;
-  display: inline-block;
-  box-sizing: border-box;
-  padding: 0.57142857em 1em;
-  border: 0;
-  border-radius: 0.28571429em;
-  margin: 0;
-  vertical-align: middle;
-  font-size: 0.875em;
-  line-height: normal;
-  text-decoration: none;
-  cursor: pointer;
-  transition: background-color 0.1s;
-  -webkit-appearance: none;
-}
-
-.btn, .btn:link, .btn:visited {
-  background-color: $action_color;
-  color: $white;
-}
-
-.btn.hover, .btn:hover {
-  background-color: $action_color_dark;
-}
-
-.btn.focus, .btn:focus {
-  background-color: $action_color_dark;
-  outline: $action_color dotted 1px;
-  outline-offset: 1px;
 }
 
 /*

--- a/regulations/static/regulations/css/scss/comment/_comment-confirm.scss
+++ b/regulations/static/regulations/css/scss/comment/_comment-confirm.scss
@@ -18,11 +18,11 @@ Contains styles for Comment confirmation success/fail/invalid pages.
     padding: 15px 10px 10px;
 
     &.success-alert {
-      background-color: $green_lightest;
+      background-color: $success_color;
     }
 
     &.fail-alert {
-      background-color: $pink;
+      background-color: $warning_color;
     }
 
     .fa-check-circle,
@@ -127,7 +127,7 @@ Contains styles for Comment confirmation success/fail/invalid pages.
     }
 
     .status {
-      background-color: $blue_lightest;
+      background-color: $notice_color;
       padding: 8px 16px;
       margin: 0;
 
@@ -141,7 +141,7 @@ Contains styles for Comment confirmation success/fail/invalid pages.
     }
 
     .status-waiting {
-      background-color: $blue_lightest;
+      background-color: $notice_color;
       padding: 8px 16px;
       margin: 1px 0;
 
@@ -152,7 +152,7 @@ Contains styles for Comment confirmation success/fail/invalid pages.
     }
 
     .tracking-number-retrieved {
-      background-color: $green_lightest;
+      background-color: $success_color;
     }
   }
 

--- a/regulations/static/regulations/css/scss/comment/_comment-media-queries.scss
+++ b/regulations/static/regulations/css/scss/comment/_comment-media-queries.scss
@@ -184,7 +184,7 @@ comment-media-queries.scss contains media query styles for Notice and Comment
   }
 
   .preamble-header {
-    background: $gray_lightest;
+    background: $panel_background_color;
     left: 40px;
     z-index: 10;
 
@@ -198,8 +198,8 @@ comment-media-queries.scss contains media query styles for Notice and Comment
 
     .read-proposal,
     .write-comment {
-      border-bottom: 1px solid $gray_light;
-      border-top: 1px solid $gray_light;
+      border-bottom: 1px solid $panel_border_color;
+      border-top: 1px solid $panel_border_color;
       width: 50% !important;
     }
 

--- a/regulations/static/regulations/css/scss/comment/_comment-read.scss
+++ b/regulations/static/regulations/css/scss/comment/_comment-read.scss
@@ -106,7 +106,7 @@ Preamble Read Mode
       height: 10px;
       width: 10px;
       vertical-align: middle;
-      background-color: $panel_background_color;
+      background-color: $gray_light;
 
       &.current {
         background-color: $action_color;

--- a/regulations/static/regulations/css/scss/comment/_comment-read.scss
+++ b/regulations/static/regulations/css/scss/comment/_comment-read.scss
@@ -45,11 +45,11 @@ Preamble Read Mode
     width: 250px;
 
     a {
-      color: $blue_light;
+      color: $action_color;
       display: block;
 
       &:hover {
-        color: $blue;
+        color: $action_color_dark;
       }
     }
 
@@ -72,9 +72,9 @@ Preamble Read Mode
 
   // hidden content (with stars) on CFR
   .show-more-context {
-    background-color: $gray_lightest;
+    background-color: $panel_background_color;
     border-radius: 2px;
-    color: $blue_light;
+    color: $action_color;
     font-size: 10px;
     margin: 10px 0;
     text-align: center;
@@ -106,10 +106,10 @@ Preamble Read Mode
       height: 10px;
       width: 10px;
       vertical-align: middle;
-      background-color: $gray_lighter;
+      background-color: $panel_background_color;
 
       &.current {
-        background-color: $blue_light;
+        background-color: $action_color;
       }
     }
   }

--- a/regulations/static/regulations/css/scss/comment/_comment-review.scss
+++ b/regulations/static/regulations/css/scss/comment/_comment-review.scss
@@ -254,7 +254,7 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
     }
 
     span {
-      color: $gray;
+      color: $gray_darker;
     }
 
     fieldset {

--- a/regulations/static/regulations/css/scss/comment/_comment-review.scss
+++ b/regulations/static/regulations/css/scss/comment/_comment-review.scss
@@ -150,7 +150,7 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
     }
 
     .details {
-      color: $gray_darker;
+      color: $panel_text_color;
       float: right;
       font-size: 14px;
       text-align: right;
@@ -254,7 +254,7 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
     }
 
     span {
-      color: $gray_light;
+      color: $gray;
     }
 
     fieldset {

--- a/regulations/static/regulations/css/scss/comment/_comment-review.scss
+++ b/regulations/static/regulations/css/scss/comment/_comment-review.scss
@@ -80,14 +80,14 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
   }
 
   .edit-comment {
-    color: $blue_light;
+    color: $action_color;
     cursor: pointer;
     position: absolute;
     right: 2%;
     top: 0;
 
     .write-icon {
-      fill: $blue_light;
+      fill: $action_color;
     }
 
     span:hover {
@@ -130,12 +130,12 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
   }
 
   .download-comment {
-    background: $blue_lightest;
+    background: $panel_highlight_color;
     border-top: 1px solid $text_area_border;
     padding: 10px 15px;
 
     h4 {
-      color: $blue_light;
+      color: $action_color;
       margin: 0;
       float: left;
       font-size: 18px;
@@ -307,12 +307,12 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
 
     .show-more-toggle {
       display: inline;
-      color: $blue_light;
+      color: $action_color;
       cursor: pointer;
       font-size: 14px;
 
       &:hover {
-        color: $blue;
+        color: $action_color_dark;
       }
 
       .text-expand {
@@ -323,9 +323,9 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
   }
 
   .submit-button {
-    background: $blue_light;
+    background: $action_color;
     border-radius: 3px;
-    color: #FFF;
+    color: $white;
     font-size: 17px;
     font-weight: bold;
     height: auto;
@@ -336,7 +336,7 @@ comment-review.scss contains styles for Review Your Comment page and the PDF it 
       color: $black;
     }
     &:hover {
-      background-color: $blue_light;
+      background-color: $action_color_dark;
     }
   }
 }

--- a/regulations/static/regulations/css/scss/comment/_comment-write.scss
+++ b/regulations/static/regulations/css/scss/comment/_comment-write.scss
@@ -24,7 +24,7 @@ Preamble Write Mode
 
       .comment-header-link a {
         color: $black;
-        border-bottom: 2px solid $blue_light;
+        border-bottom: 2px solid $action_color;
       }
     }
 
@@ -38,7 +38,7 @@ Preamble Write Mode
 
     // Show toggle box
     a.comment-context-toggle {
-      background-color: $gray_lightest;
+      background-color: $panel_background_color;
       border-radius: 2px;
       color: $panel_text_color;
       cursor: pointer;
@@ -47,7 +47,7 @@ Preamble Write Mode
       padding: 10px 15px;
 
       .comment-context-text {
-        color: $blue_light;
+        color: $action_color;
       }
 
       .fa-minus-circle,
@@ -161,7 +161,7 @@ Preamble Write Mode
 
   .comment-button,
   a.comment-index-review {
-    background-color: $blue_light;
+    background-color: $action_color;
     border-radius: 2px;
     color: $white;
     @include sans-font-regular;
@@ -176,7 +176,7 @@ Preamble Write Mode
     transition: .1s;
 
     &:hover {
-      background-color: $blue;
+      background-color: $action_color_dark;
     }
   }
 

--- a/regulations/static/regulations/css/scss/comment/_comment-write.scss
+++ b/regulations/static/regulations/css/scss/comment/_comment-write.scss
@@ -40,7 +40,7 @@ Preamble Write Mode
     a.comment-context-toggle {
       background-color: $gray_lightest;
       border-radius: 2px;
-      color: $gray_darker;
+      color: $panel_text_color;
       cursor: pointer;
       display: block;
       font-size: 16px;
@@ -111,7 +111,7 @@ Preamble Write Mode
       .ProseMirror-menubar {
         min-height: 28px;
         padding: 3px 6px;
-        color: $gray_darker;
+        color: $panel_text_color;
         border-bottom: 1px solid $gray_light;
       }
 
@@ -377,7 +377,7 @@ Preamble Write Mode
     }
 
     &:hover {
-      background: lighten($gray, 10%);
+      background: $gray_light;
 
       .fa {
         display: inline-block;

--- a/regulations/static/regulations/css/scss/comment/_comment.scss
+++ b/regulations/static/regulations/css/scss/comment/_comment.scss
@@ -18,7 +18,7 @@ N&C Header - including Read/Write tab
 
   .tab-descriptions {
     font-size: 14px;
-    color: $gray_darker;
+    color: $panel_text_color;
     padding: 0 5px;
   }
 
@@ -32,7 +32,7 @@ N&C Header - including Read/Write tab
 
   .read-proposal,
   .write-comment {
-    border-left: 1px solid $gray_light;
+    border-left: 1px solid $panel_border_color;
     color: $panel_text_color;
     cursor: pointer;
     display: inline-block;
@@ -65,7 +65,7 @@ N&C Header - including Read/Write tab
     }
 
     &:hover:not(.active-mode) {
-      background: $gray_light;
+      background: $white;
       height: 33px;
     }
   }

--- a/regulations/static/regulations/css/scss/comment/_comment.scss
+++ b/regulations/static/regulations/css/scss/comment/_comment.scss
@@ -33,7 +33,7 @@ N&C Header - including Read/Write tab
   .read-proposal,
   .write-comment {
     border-left: 1px solid $gray_light;
-    color: $gray_darker;
+    color: $panel_text_color;
     cursor: pointer;
     display: inline-block;
     @include sans-font-regular;
@@ -44,7 +44,7 @@ N&C Header - including Read/Write tab
     width: 245px;
 
     a {
-      color: $gray_darker;
+      color: $panel_text_color;
       padding-left: 5px;
     }
 
@@ -52,32 +52,32 @@ N&C Header - including Read/Write tab
     .write-icon {
       padding: 0;
       font-size: 14px;
-      fill: $gray_darker;
+      fill: $panel_text_color;
     }
 
     &.active-mode a {
-      color: $blue;
+      color: $primary_color;
     }
 
     &:hover span,
     &:hover a {
-      color: $blue;
+      color: $primary_color;
     }
 
     &:hover:not(.active-mode) {
-      background: lighten($gray, 10%);
+      background: $gray_light;
       height: 33px;
     }
   }
 
   .active-mode {
     background: $white;
-    color: $blue;
+    color: $primary_color;
     cursor: default;
 
     .read-icon,
     .write-icon {
-      fill: $blue;
+      fill: $primary_color;
     }
   }
 }
@@ -90,4 +90,3 @@ N&C Header - including Read/Write tab
   // for adding a draft watermark to PDFs of unsubmitted comments
   background-image: url('../img/draft_watermark.png');
 }
-

--- a/regulations/static/regulations/css/scss/module/_diffs.scss
+++ b/regulations/static/regulations/css/scss/module/_diffs.scss
@@ -16,12 +16,12 @@ del {
 }
 
 ins {
-  background-color: $green_lightest;
+  background-color: $text_highlight_color;
   text-decoration: none;
   font-style: italic;
 
   .key-term {
-    background-color: $green_lightest;
+    background-color: $text_highlight_color;
     text-decoration: none;
     @include serif-font-italic;
 
@@ -32,7 +32,7 @@ ins {
   }
 
   img {
-      border: 2px solid $green_lightest;
+      border: 2px solid $text_highlight_color;
   }
 }
 

--- a/regulations/static/regulations/css/scss/module/_forms.scss
+++ b/regulations/static/regulations/css/scss/module/_forms.scss
@@ -19,7 +19,7 @@ button {
   height: 32px;
   vertical-align: bottom;
   margin: 0;
-  background-color: $blue_light;
+  background-color: $action_color;
   color: $white;
   border: none;
   text-align: center;
@@ -30,12 +30,12 @@ button {
 
 button:hover,
 button:active {
-  background-color: $blue_light;
+  background-color: $action_color_dark;
 }
 
 textarea:focus,
 input:focus {
-  border: 1px solid $blue_light;
+  border: 1px solid $action_color;
 }
 
 .file-upload {

--- a/regulations/static/regulations/css/scss/module/_search-results.scss
+++ b/regulations/static/regulations/css/scss/module/_search-results.scss
@@ -46,7 +46,7 @@ p.search-version {
   }
 
   .internal {
-    color: $blue_light;
+    color: $action_color;
   }
 }
 
@@ -56,13 +56,13 @@ p.search-version {
   a:link,
   a:visited {
     @include sans-font-bold;
-    color: $blue_light;
+    color: $action_color;
     text-decoration: none;
   }
 
   a:hover,
   a:active {
-    border-bottom: 1px solid $blue_light;
+    border-bottom: 1px solid $action_color;
   }
 
   .next {

--- a/regulations/static/regulations/css/scss/partials/_drawer-content.scss
+++ b/regulations/static/regulations/css/scss/partials/_drawer-content.scss
@@ -109,7 +109,7 @@ This contains all of the styles specific to the TOC
 
   a:link,
   a:visited {
-    color: $gray_darker;
+    color: $panel_text_color;
     @include border-bottom-light ($width: 1px);
   }
 
@@ -119,7 +119,7 @@ This contains all of the styles specific to the TOC
     margin-left: -100px;
     padding-left: 105px;
     color: $black;
-    background-color: $blue_lightest;
+    background-color: $panel_highlight_color;
   }
 
   /*
@@ -160,7 +160,7 @@ This contains all of the styles specific to the TOC
   padding: 10px 0 10px 105px;
   display: block;
   line-height: 1.4;
-  background-color: $gray_lightest;
+  background-color: $panel_background_color;
   @include border-bottom-light ($width: 1px);
   @include regulation-nav-subpart-heading-font;
 }
@@ -191,7 +191,7 @@ This contains all of the styles specific to the history
   .effective-label {
     padding: 0 15px;
     @include sans-font-regular;
-    color: $gray_darker;
+    color: $panel_text_color;
   }
 
   // TODO: unify link styles with TOC
@@ -217,16 +217,16 @@ This contains all of the styles specific to the history
   .current {
     .version-link {
       padding: 10px 15px 0 15px;
-      background: $blue_lightest;
+      background: $panel_highlight_color;
     }
 
     .timeline-content-wrap {
-      background: $blue_lightest;
+      background: $panel_highlight_color;
     }
 
     .rule-list {
       display: block;
-      background: $blue_lightest;
+      background: $panel_highlight_color;
     }
   }
 
@@ -243,7 +243,7 @@ This contains all of the styles specific to the history
   .version-link:target,
   .current {
     color: $black;
-    background: $blue_lightest;
+    background: $panel_highlight_color;
     display: block;
   }
 
@@ -272,7 +272,7 @@ This contains all of the styles specific to the history
   }
 
   .rule-status {
-    color: $gray_darker;
+    color: $panel_text_color;
     text-transform: lowercase;
     @include sans-font-regular;
     display: block;
@@ -356,7 +356,7 @@ This contains all of the styles specific to the history
   #history {
     li:hover,
     li.current {
-      background-color: $blue_lightest;
+      background-color: $panel_highlight_color;
     }
   }
 }
@@ -405,7 +405,7 @@ This contains all of the styles specific to the search
   }
 
   h3 {
-    color: $gray_darker;
+    color: $panel_text_color;
     @include sans-font-regular;
     font-size: 0.875em;
     line-height: normal;

--- a/regulations/static/regulations/css/scss/partials/_drawer-content.scss
+++ b/regulations/static/regulations/css/scss/partials/_drawer-content.scss
@@ -30,14 +30,14 @@ This contains all of the styles specific to the TOC
 
     .toc-entry-at-1,
     .toc-entry-at-1:hover {
-      border-top: 1px solid $gray_light;
+      border-top: 1px solid $panel_border_color;
       @include sans-font-bold;
       margin-left: -100px;
       padding: 9px 0 9px 110px;
     }
 
     .toc-depth-2 {
-      border-top: 1px solid $gray_light;
+      border-top: 1px solid $panel_border_color;
       margin-left: -100px;
       padding: 0 0 0 105px;
 

--- a/regulations/static/regulations/css/scss/partials/_drawer.scss
+++ b/regulations/static/regulations/css/scss/partials/_drawer.scss
@@ -8,20 +8,20 @@ Regulation Drawer
 
 // Universal drawer styles
 .panel {
-  background-color: $gray_lightest;
-  border-right: 2px solid $gray_light;
+  background-color: $panel_background_color;
+  border-right: 2px solid $panel_border_color;
   @include sans-font-regular;
   font-size: 1em;
   overflow-y: scroll; // allow content to be scrollable
 }
 
 .toc-head {
-  border-right: 2px solid $gray_light;
+  border-right: 2px solid $panel_border_color;
   transition: 0.1s;
 
   a:link,
   a:visited {
-    color: $gray_darker;
+    color: $panel_text_color;
     text-decoration: none;
     height: 33px;
   }
@@ -30,7 +30,7 @@ Regulation Drawer
   a:hover,
   a.current {
     background-color: $white;
-    color: $blue;
+    color: $primary_color;
     height: 34px;
   }
 
@@ -55,8 +55,8 @@ Drawer default state
 .drawer-header {
   position: fixed;
   background-color: $white;
-  border-right: 2px solid $gray_light;
-  border-bottom: 1px solid $gray_light;
+  border-right: 2px solid $panel_border_color;
+  border-bottom: 1px solid $panel_border_color;
 
   .toc-type,
   .toc-subheader {
@@ -76,14 +76,14 @@ Drawer default state
   }
 
   h2 {
-    color: $blue;
+    color: $primary_color;
     font-size: 0.875em;
     text-transform: uppercase;
     font-weight: bold;
   }
 
   h3 {
-    color: $blue;
+    color: $primary_color;
     @include sans-font-regular;
     font-size: 0.875em;
     text-transform: capitalize;
@@ -113,7 +113,7 @@ Panel Slide Button
   }
 
   .close & {
-    border-bottom: 1px solid $gray_light;
+    border-bottom: 1px solid $panel_border_color;
 
     img:first-child {
       display: inline-block;
@@ -161,8 +161,8 @@ currently these are TOC, History, and Search
   margin: 0;
   width: 56px;
   text-align: center;
-  background-color: $gray_lightest;
-  color: $gray_darker;
+  background-color: $panel_background_color;
+  color: $panel_text_color;
 
   &.current {
     background-color: $white;
@@ -200,7 +200,7 @@ currently these are TOC, History, and Search
   }
 
   .toc-nav-link:hover {
-    background-color: $gray_light;
+    background-color: $panel_background_color;
     border-bottom: none;
   }
 }
@@ -222,7 +222,7 @@ currently these are TOC, History, and Search
     position: absolute;
     width: $closed_drawer_width;
     top: 33px;
-    border-top: 1px solid $gray_light;
+    border-top: 1px solid $panel_border_color;
     right: 0;
     left: 198px;
   }
@@ -232,13 +232,13 @@ currently these are TOC, History, and Search
   display: inline-block;
   zoom: 1;
   margin-left: -4px;
-  border-right: 1px solid $gray_light;
-  border-left: 1px solid $gray_light;
+  border-right: 1px solid $panel_border_color;
+  border-left: 1px solid $panel_border_color;
 
   .close & {
     margin-left: 0;
     display: list-item;
-    border-bottom: 1px solid $gray_light;
+    border-bottom: 1px solid $panel_border_color;
     border-right: none;
   }
 }

--- a/regulations/static/regulations/css/scss/partials/_footer.scss
+++ b/regulations/static/regulations/css/scss/partials/_footer.scss
@@ -138,7 +138,7 @@ Link Styles
 
 .next-prev-link:link,
 .next-prev-link:visited {
-  color: $blue_light;
+  color: $action_color;
   text-decoration: none;
 }
 

--- a/regulations/static/regulations/css/scss/partials/_header.scss
+++ b/regulations/static/regulations/css/scss/partials/_header.scss
@@ -4,7 +4,7 @@
 
 .reg-header {
   width: 100%;
-  color: $gray_darker;
+  color: $panel_text_color;
   @include sans-font-regular;
   position: absolute;
   height: $mainhead_height + $subhead_height;
@@ -21,7 +21,7 @@
 }
 
 .main-head {
-  border-bottom: 2px solid $blue;
+  border-bottom: 2px solid $primary_color;
   background: $white;
   position: fixed;
   top: 0;
@@ -40,12 +40,12 @@
   a {
     &:link,
     &:visited {
-      color: $blue;
+      color: $primary_color;
     }
 
     &:hover,
     &:active {
-      color: $blue_dark;
+      color: $primary_color_dark;
     }
   }
 
@@ -94,20 +94,20 @@
 .title a:link,
 .title a:visited {
   border-bottom: none;
-  color: $blue;
+  color: $primary_color;
   text-decoration: none;
 }
 
 .title a:hover,
 .title a:active {
-  color: $blue_dark;
+  color: $primary_color_dark;
 }
 
 .sub-head {
   position: fixed;
   top: $mainhead_height;
   min-width: 100%;
-  background: $gray_lightest;
+  background: $panel_background_color;
   color: $black;
   line-height: 35px;
   height: 2.125em;
@@ -115,7 +115,7 @@
   z-index: 200;
 
   .main {
-    border-right: 1px solid $gray_dark;
+    border-right: 1px solid $panel_border_color;
   }
 }
 
@@ -188,13 +188,13 @@ Application Nav
 
   &:link,
   &:visited {
-    color: $blue;
+    color: $primary_color;
   }
 
   &:hover,
   &:active,
   &:focus {
-    color: $blue_dark;
+    color: $primary_color_dark;
   }
 }
 
@@ -240,12 +240,12 @@ BIG SCREENS
     margin: 0 0 0 24px;
 
     a {
-      color: $gray_darker;
+      color: $panel_text_color;
       padding: 0;
     }
 
     &:last-child {
-      border-bottom: 2px solid $gray_dark;
+      border-bottom: 2px solid $panel_border_color;
     }
 
     .logo {
@@ -313,12 +313,12 @@ tiny screens
     position: fixed;
     top: 60px;
     width: 100%;
-    background: $gray_lightest;
+    background: $panel_background_color;
     z-index: 999999;
   }
 
   .app-nav-list-item {
-    border-bottom: 1px solid $gray_light;
+    border-bottom: 1px solid $panel_border_color;
     z-index: 999999;
 
     a {
@@ -345,7 +345,7 @@ tiny screens
   .mobile-nav-trigger:active,
   .mobile-nav-trigger:focus,
   .mobile-nav-trigger.open {
-    background-color: $gray_lightest;
+    background-color: $panel_background_color;
   }
 
   .title {

--- a/regulations/static/regulations/css/scss/partials/_navigation.scss
+++ b/regulations/static/regulations/css/scss/partials/_navigation.scss
@@ -37,13 +37,12 @@ Appendix Navigation
 
 .appendix-nav a:link,
 .appendix-nav a:visited {
-  color: #101820;
+  color: $black;
   text-decoration: none;
-  border-bottom: 1px solid $blue_light;
+  border-bottom: 1px solid $action_color;
 }
 
 .appendix-nav a:hover,
 .appendix-nav a:active {
-  background-color: #cde3f1;
+  background-color: $panel_highlight_color;
 }
-

--- a/regulations/static/regulations/css/scss/partials/_navigation.scss
+++ b/regulations/static/regulations/css/scss/partials/_navigation.scss
@@ -44,5 +44,6 @@ Appendix Navigation
 
 .appendix-nav a:hover,
 .appendix-nav a:active {
-  background-color: $panel_highlight_color;
+  color: $black_dark;
+  border-bottom: 1px solid $action_color_dark;
 }


### PR DESCRIPTION
This PR establishes the "themeable variables" in eregs and elements now reference the theme variable than the palette directly. Currently I put these at the bottom of `_base-variables` but maybe they should live in another file? 

To use the theme you just have to define any of those variables in the project that wraps regulation-site. For instance, you can write `$primary_color: DarkSalmon` in the `variables.scss` in 18f/epa-notice and it will turn everything that was blue into fish colors. You only have to re-define the variables you want to use. That's what `!default` is doing.

Not every color variable is themeable right now. For instance, everything that is `$white` will stay that way. There are some grays that stay the same too (secondary button color). 

