### PR TITLE
Fixing table width bugs

### DIFF
--- a/regulations/static/regulations/css/scss/_typography.scss
+++ b/regulations/static/regulations/css/scss/_typography.scss
@@ -586,14 +586,6 @@ table.dataTable {
   }
 }
 
-table.dataTable,
-table.dataTable th,
-table.dataTable td {
-  -webkit-box-sizing: content-box;
-  -moz-box-sizing: content-box;
-  box-sizing: content-box;
-}
-
 /*
   Code Styles
  ========================================================================== */

--- a/regulations/templates/regulations/layers/table.html
+++ b/regulations/templates/regulations/layers/table.html
@@ -3,7 +3,7 @@
 {% endcomment %}
 <div class="table-wrap">
 {% comment %}
-    The Datatables jquery plugin requires a width of 100% on table tags to 
+    The Datatables jquery plugin requires a width of 100% on table tags to
     correctly calulate relative sizes
 {% endcomment %}
     <table width="100%">


### PR DESCRIPTION
Fixes 18F/eregs-platform#26

Removing the box-sizing styles on the table element seems to fix this (tested in Firefox). They seem to mess with how the width calculation is performed. I'll try to test in IE11 too when I get home unless someone gets to it first.