### PR TITLE
Add whole page caching to the preamble

### DIFF
--- a/regulations/settings/base.py
+++ b/regulations/settings/base.py
@@ -33,7 +33,7 @@ ALLOWED_HOSTS = []
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
 # In a Windows environment this must be set to your system time zone.
-TIME_ZONE = 'America/Chicago'
+TIME_ZONE = 'America/New_York'
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html

--- a/regulations/tests/url_cache_tests.py
+++ b/regulations/tests/url_cache_tests.py
@@ -1,0 +1,37 @@
+from datetime import date
+
+from django.http import HttpResponse
+from django.test import TestCase
+from django.test.client import RequestFactory
+from django.utils.decorators import decorator_from_middleware_with_args
+from mock import Mock, patch
+
+from regulations import url_caches
+
+
+class UrlCachesTests(TestCase):
+    @patch('regulations.url_caches.date')
+    def test_daily_cache(self, patched_date):
+        """Cache should be consistent within a day but not between days"""
+        fn = Mock(return_value=HttpResponse('response'))
+        request = RequestFactory().get('a-path')
+
+        mock_caches = {'example': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}}
+        with self.settings(CACHES=mock_caches):
+            daily_cache = decorator_from_middleware_with_args(
+                url_caches.DailyCacheMiddleware)(cache_alias='example')
+            wrapped_fn = daily_cache(fn)
+
+        patched_date.today.return_value = date(2010, 10, 10)
+        self.assertEqual(fn.call_count, 0)
+        wrapped_fn(request)
+        self.assertEqual(fn.call_count, 1)
+        wrapped_fn(request)
+        self.assertEqual(fn.call_count, 1)
+
+        patched_date.today.return_value = date(2010, 10, 11)
+        wrapped_fn(request)
+        self.assertEqual(fn.call_count, 2)
+        wrapped_fn(request)
+        self.assertEqual(fn.call_count, 2)

--- a/regulations/url_caches.py
+++ b/regulations/url_caches.py
@@ -1,0 +1,26 @@
+from datetime import date
+
+from django.conf import settings
+from django.utils.decorators import decorator_from_middleware_with_args
+from django.views.decorators.cache import cache_page
+from django.middleware.cache import CacheMiddleware
+
+
+lt_cache = cache_page(settings.CACHES['eregs_longterm_cache']['TIMEOUT'],
+                      cache='eregs_longterm_cache')
+
+
+class DailyCacheMiddleware(CacheMiddleware):
+    """Like the cache middleware, but always expires at midnight"""
+    @property
+    def key_prefix(self):
+        return date.today().isoformat() + '/' + (self.__key_prefix or '')
+
+    @key_prefix.setter
+    def key_prefix(self, value):
+        self.__key_prefix = value
+
+
+daily_cache = decorator_from_middleware_with_args(DailyCacheMiddleware)(
+    cache_timeout=settings.CACHES['eregs_longterm_cache']['TIMEOUT'],
+    cache_alias='eregs_longterm_cache')

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -1,7 +1,6 @@
-from django.conf import settings
 from django.conf.urls import url
-from django.views.decorators.cache import cache_page
 
+from regulations.url_caches import daily_cache, lt_cache
 from regulations.views.about import about
 from regulations.views.chrome_breakaway import ChromeSXSView
 from regulations.views.chrome import (
@@ -37,9 +36,6 @@ section_pattern = r'(?P<label_id>[\d]+[-][\w]+)'
 interp_pattern = r'(?P<label_id>[-\w]+[-]Interp)'
 paragraph_pattern = r'(?P<label_id>[-\w]+)'
 subterp_pattern = r'(?P<label_id>[\d]+-(Appendices|Subpart(-[A-Z]+)?)-Interp)'
-
-lt_cache = cache_page(settings.CACHES['eregs_longterm_cache']['TIMEOUT'],
-                      cache='eregs_longterm_cache')
 
 
 urlpatterns = [
@@ -84,9 +80,9 @@ urlpatterns = [
         name='chrome_section_diff_view'),
 
     url(r'^preamble/(?P<doc_number>[\w-]+)/cfr_changes/(?P<section>[\w-]+)$',
-        CFRChangesView.as_view(), name='cfr_changes'),
+        daily_cache(CFRChangesView.as_view()), name='cfr_changes'),
     url(r'^preamble/(?P<paragraphs>[-\w]+(/[-\w]+)*)$',
-        PreambleView.as_view(), name='chrome_preamble'),
+        daily_cache(PreambleView.as_view()), name='chrome_preamble'),
 
     # Redirect to version by date
     # Example: http://.../201-3-v/1999/11/8


### PR DESCRIPTION
This cache expires at midnight to account for comment closing dates, etc.