### PR TITLE
Add background to regulation images

### DIFF
--- a/regulations/static/regulations/css/scss/main.scss
+++ b/regulations/static/regulations/css/scss/main.scss
@@ -256,6 +256,7 @@ img.reg-image {
   margin-right: auto;
   display: block;
   border: 1px solid $gray_light;
+  background-color: $white;
 }
 
 .block-image {


### PR DESCRIPTION
Only noticeable when the image is inside an EXTRACT

## Before
<img width="613" alt="screen shot 2016-07-29 at 6 24 22 pm" src="https://cloud.githubusercontent.com/assets/326918/17265086/e9a37240-55b9-11e6-9045-d1a8b7900c70.png">

## After
<img width="607" alt="screen shot 2016-07-29 at 6 24 30 pm" src="https://cloud.githubusercontent.com/assets/326918/17265085/e99f544e-55b9-11e6-91dd-0581dd906d1f.png">

Part of 18F/eregs-platform#36
