### PR TITLE
[WIP] Render section spans

### DIFF
--- a/regulations/generator/title_parsing.py
+++ b/regulations/generator/title_parsing.py
@@ -42,8 +42,16 @@ def section(data):
     if len(data['index']) == 2 and data['index'][1][0].isdigit():
         element = {}
         element['is_section'] = True
-        element['label'] = '.'.join(data['index'])
         element['section_id'] = '-'.join(data['index'])
-        element['sub_label'] = re.search(
-            element['label'] + r'[^\w\[]*(.*)', data['title']).group(1)
+        if u"§§ " == data['title'][:3]:
+            element['is_section_span'] = True
+            match = re.match(
+                    r'([-.\w]*)' + r'[^\w\[]*(.*)', data['title'][3:])
+            element['label'] = match.group(1)
+            element['sub_label'] = match.group(2)
+        else:
+            element['is_section_span'] = False
+            element['label'] = '.'.join(data['index'])
+            element['sub_label'] = re.search(
+                element['label'] + r'[^\w\[]*(.*)', data['title']).group(1)
         return element

--- a/regulations/generator/title_parsing.py
+++ b/regulations/generator/title_parsing.py
@@ -3,6 +3,13 @@ import re
 
 from regulations.generator import node_types
 
+# A section title comprises
+#   - one or more §
+#   - a section label like 11.45 or 11.45-50
+#   - one or more space or - separators
+#   - a section subject
+SECTION_TITLE_REGEX = re.compile(u'^§+ ([-.\w]*)[\s-]*(.*)', re.UNICODE)
+
 
 def appendix_supplement(data):
     """Handle items pointing to an appendix or supplement"""
@@ -45,13 +52,9 @@ def section(data):
         element['section_id'] = '-'.join(data['index'])
         if u"§§ " == data['title'][:3]:
             element['is_section_span'] = True
-            match = re.match(
-                    r'([-.\w]*)' + r'[^\w\[]*(.*)', data['title'][3:])
-            element['label'] = match.group(1)
-            element['sub_label'] = match.group(2)
         else:
             element['is_section_span'] = False
-            element['label'] = '.'.join(data['index'])
-            element['sub_label'] = re.search(
-                element['label'] + r'[^\w\[]*(.*)', data['title']).group(1)
+        match = SECTION_TITLE_REGEX.match(data['title'])
+        element['label'] = match.group(1)
+        element['sub_label'] = match.group(2)
         return element

--- a/regulations/templates/regulations/toc-section.html
+++ b/regulations/templates/regulations/toc-section.html
@@ -1,1 +1,3 @@
-<li><a href="{{item.url}}" data-section-id="{{item.section_id}}" id="nav-{{item.section_id}}"><span class="toc-section-marker">§&nbsp;{{item.label}}</span> {{item.sub_label|safe}}</a></li>
+<li><a href="{{item.url}}" data-section-id="{{item.section_id}}" id="nav-{{item.section_id}}">
+        <span class="toc-section-marker">{% if item.is_section_span%}§§&nbsp;{% else %}§&nbsp;{% endif %} {{item.label}}</span> {{item.sub_label|safe}}
+</a></li>

--- a/regulations/templates/regulations/toc-section.html
+++ b/regulations/templates/regulations/toc-section.html
@@ -1,3 +1,3 @@
 <li><a href="{{item.url}}" data-section-id="{{item.section_id}}" id="nav-{{item.section_id}}">
-        <span class="toc-section-marker">{% if item.is_section_span%}§§&nbsp;{% else %}§&nbsp;{% endif %} {{item.label}}</span> {{item.sub_label|safe}}
+        <span class="toc-section-marker">{% if item.is_section_span%}§§&nbsp;{% else %}§&nbsp;{% endif %}{{item.label}}</span> {{item.sub_label|safe}}
 </a></li>

--- a/regulations/tests/generator_toc_tests.py
+++ b/regulations/tests/generator_toc_tests.py
@@ -41,9 +41,9 @@ class TocTest(TestCase):
         self.assertTrue(result['is_appendix'])
 
     def test_toc_subpart(self):
-        layer = {'1001-Subpart-A': [{'title': '1001.1 - Content',
+        layer = {'1001-Subpart-A': [{'title': u'§ 1001.1 - Content',
                                      'index': ['1001', '1']},
-                                    {'title': '1001.2 - Other',
+                                    {'title': u'§ 1001.2 - Other',
                                      'index': ['1001', '2']}]}
         data = {'title': u'General', 'index': ['1001', 'Subpart', 'A']}
         result = toc.toc_subpart(data, [], layer)
@@ -61,9 +61,9 @@ class TocTest(TestCase):
         self.assertEqual(['1001', '2'], s2['index'])
 
     def test_toc_subpart_with_nondigits(self):
-        layer = {'1001-Subpart-A': [{'title': '1001.1a - Content',
+        layer = {'1001-Subpart-A': [{'title': u'§ 1001.1a - Content',
                                      'index': ['1001', '1a']},
-                                    {'title': '1001.2 - Other',
+                                    {'title': u'§ 1001.2 - Other',
                                      'index': ['1001', '2']}]}
         data = {'title': u'General', 'index': ['1001', 'Subpart', 'A']}
         result = toc.toc_subpart(data, [], layer)

--- a/regulations/tests/layers_toc_applier_tests.py
+++ b/regulations/tests/layers_toc_applier_tests.py
@@ -22,7 +22,7 @@ class TableOfContentsLayerTest(TestCase):
         toc.section(el, {'index': ['1', 'Interpretations']})
         self.assertEqual({}, el)
 
-        toc.section(el, {'index': ['1', '2'], 'title': '1.2 - Awesome'})
+        toc.section(el, {'index': ['1', '2'], 'title': u'§ 1.2 - Awesome'})
         self.assertEqual(el, {
             'is_section': True,
             'is_section_span': False,
@@ -31,13 +31,25 @@ class TableOfContentsLayerTest(TestCase):
             'sub_label': 'Awesome'
         })
 
-        toc.section(el, {'index': ['2', '1'], 'title': '2.1Sauce'})
+        toc.section(el, {'index': ['2', '1'], 'title': u'§ 2.1 Sauce'})
         self.assertEqual(el, {
             'is_section': True,
             'is_section_span': False,
             'section_id': '2-1',
             'label': '2.1',
             'sub_label': 'Sauce'
+        })
+
+    def test_section_with_thin_space(self):
+        toc = TableOfContentsLayer(None)
+        el = {}
+        toc.section(el, {'index': ['1', '2'], 'title': u'§ 1.2 -  Awesome'})
+        self.assertEqual(el, {
+            'is_section': True,
+            'is_section_span': False,
+            'section_id': '1-2',
+            'label': '1.2',
+            'sub_label': 'Awesome'
         })
 
     def test_section_span(self):
@@ -107,7 +119,7 @@ class TableOfContentsLayerTest(TestCase):
 
     def test_apply_layer_url(self):
         toc = TableOfContentsLayer({'100': [
-            {'title': '100.1 Intro', 'index': ['100', '1']}]})
+            {'title': u'§ 100.1 Intro', 'index': ['100', '1']}]})
 
         result = toc.apply_layer('100')
         self.assertEqual('#100-1', result[1][0]['url'])
@@ -119,7 +131,7 @@ class TableOfContentsLayerTest(TestCase):
 
     def test_apply_layer_compatibility(self):
         toc = TableOfContentsLayer({'100': [
-            {'title': '100.1 Intro', 'index': ['100', '1']},
+            {'title': u'§ 100.1 Intro', 'index': ['100', '1']},
             {'title': 'Appendix A', 'index': ['100', 'A']},
             {'title': 'Supplement I', 'index': ['100', 'Interp']}]})
         _, result = toc.apply_layer('100')
@@ -131,9 +143,9 @@ class TableOfContentsLayerTest(TestCase):
                 {'title': 'Appendix A', 'index': ['100', 'A']},
                 {'title': 'Supplement I', 'index': ['100', 'Interp']}],
             '100-Subpart-A': [
-                {'title': '100.1 Intro', 'index': ['100', '1']},
-                {'title': '100.2 Sec2', 'index': ['100', '2']},
-                {'title': '100.3 Sec3', 'index': ['100', '3']}]
+                {'title': u'§ 100.1 Intro', 'index': ['100', '1']},
+                {'title': u'§ 100.2 Sec2', 'index': ['100', '2']},
+                {'title': u'§ 100.3 Sec3', 'index': ['100', '3']}]
             })
         _, result = toc.apply_layer('100')
         self.assertEqual(3, len(result))
@@ -161,8 +173,8 @@ class TableOfContentsLayerTest(TestCase):
 
     def test_apply_layer_interp_emptysubpart(self):
         toc = TableOfContentsLayer({'100': [
-            {'title': '100.1 Intro', 'index': ['100', '1']},
-            {'title': '100.2 Second', 'index': ['100', '2']},
+            {'title': u'§ 100.1 Intro', 'index': ['100', '1']},
+            {'title': u'§ 100.2 Second', 'index': ['100', '2']},
             {'title': 'Supplement I', 'index': ['100', 'Interp']}]})
         _, result = toc.apply_layer('100')
         self.assertEqual(3, len(result))
@@ -173,8 +185,8 @@ class TableOfContentsLayerTest(TestCase):
         self.assertEqual(['100', 'Subpart', 'Interp'], nosubpart['index'])
 
         toc = TableOfContentsLayer({'100': [
-            {'title': '100.1 Intro', 'index': ['100', '1']},
-            {'title': '100.2 Second', 'index': ['100', '2']},
+            {'title': u'§ 100.1 Intro', 'index': ['100', '1']},
+            {'title': u'§ 100.2 Second', 'index': ['100', '2']},
             {'title': 'Appendix A', 'index': ['100', 'A']},
             {'title': 'Appendix C', 'index': ['100', 'C']},
             {'title': 'Supplement I', 'index': ['100', 'Interp']}]})
@@ -194,8 +206,8 @@ class TableOfContentsLayerTest(TestCase):
                 {'title': 'Subpart A', 'index': ['100', 'Subpart', 'A']},
                 {'title': 'Supplement I', 'index': ['100', 'Interp']}],
             '100-Subpart-A': [
-                {'title': '100.1 Intro', 'index': ['100', '1']},
-                {'title': '100.2 Second', 'index': ['100', '2']}]})
+                {'title': u'§ 100.1 Intro', 'index': ['100', '1']},
+                {'title': u'§ 100.2 Second', 'index': ['100', '2']}]})
         _, result = toc.apply_layer('100')
         self.assertEqual(2, len(result))
         subpartA, interp = result
@@ -212,8 +224,8 @@ class TableOfContentsLayerTest(TestCase):
                 {'title': 'Appendix C', 'index': ['100', 'C']},
                 {'title': 'Supplement I', 'index': ['100', 'Interp']}],
             '100-Subpart-A': [
-                {'title': '100.1 Intro', 'index': ['100', '1']},
-                {'title': '100.2 Second', 'index': ['100', '2']}]})
+                {'title': u'§ 100.1 Intro', 'index': ['100', '1']},
+                {'title': u'§ 100.2 Second', 'index': ['100', '2']}]})
         _, result = toc.apply_layer('100')
         self.assertEqual(4, len(result))
         subpartA, appA, appC, interp = result

--- a/regulations/tests/layers_toc_applier_tests.py
+++ b/regulations/tests/layers_toc_applier_tests.py
@@ -1,3 +1,4 @@
+# vim: set fileencoding=utf-8
 from unittest import TestCase
 
 from regulations.generator.layers.toc_applier import (
@@ -24,6 +25,7 @@ class TableOfContentsLayerTest(TestCase):
         toc.section(el, {'index': ['1', '2'], 'title': '1.2 - Awesome'})
         self.assertEqual(el, {
             'is_section': True,
+            'is_section_span': False,
             'section_id': '1-2',
             'label': '1.2',
             'sub_label': 'Awesome'
@@ -32,9 +34,26 @@ class TableOfContentsLayerTest(TestCase):
         toc.section(el, {'index': ['2', '1'], 'title': '2.1Sauce'})
         self.assertEqual(el, {
             'is_section': True,
+            'is_section_span': False,
             'section_id': '2-1',
             'label': '2.1',
             'sub_label': 'Sauce'
+        })
+
+    def test_section_span(self):
+        toc = TableOfContentsLayer(None)
+        el = {}
+
+        toc.section(el, {
+            'index': ['1', '2'],
+            'title': u'§§ 1.2-6 - This is a span'
+        })
+        self.assertEqual(el, {
+            'is_section': True,
+            'is_section_span': True,
+            'section_id': '1-2',
+            'label': '1.2-6',
+            'sub_label': 'This is a span'
         })
 
     def test_appendix_supplement(self):

--- a/regulations/tests/title_parsing_tests.py
+++ b/regulations/tests/title_parsing_tests.py
@@ -1,3 +1,4 @@
+# vim: set fileencoding=utf-8
 from unittest import TestCase
 from regulations.generator import title_parsing
 
@@ -21,14 +22,14 @@ class RegTest(TestCase):
     def test_section(self):
         elements = title_parsing.section({
             'index': ['204', '4'],
-            'title': '204.4 Sauce'})
+            'title': u'§ 204.4 Sauce'})
 
         self.assertTrue(elements['is_section'])
         self.assertEquals('Sauce', elements['sub_label'])
 
         elements = title_parsing.section({
             'index': ['204', '4'],
-            'title': '204.4 [Reserved]'})
+            'title': u'§ 204.4 [Reserved]'})
 
         self.assertTrue(elements['is_section'])
         self.assertEquals('[Reserved]', elements['sub_label'])

--- a/regulations/tests/views_diff_tests.py
+++ b/regulations/tests/views_diff_tests.py
@@ -1,3 +1,4 @@
+# vim: set fileencoding=utf-8
 from unittest import TestCase
 
 from django.test import RequestFactory
@@ -54,7 +55,7 @@ class ChromeSectionDiffViewTests(TestCase):
                     'is_supplement':True}]
         diff = {
             '8888-2': {'op': 'added',
-                       'node': {'title': '8888.2', 'label': ['8888', '2']}},
+                       'node': {'title': u'§ 8888.2', 'label': ['8888', '2']}},
             '8888-C': {'op': 'added',
                        'node': {'title': 'App C', 'label': ['8888', 'C']}},
             '8888-1-a': {'op': 'modified'},

--- a/regulations/views/navigation.py
+++ b/regulations/views/navigation.py
@@ -10,7 +10,10 @@ def _add_extra(el, version):
     """Add extra fields to a TOC element -- only added to elements we will
     use for prev/next"""
     if el.get('is_section'):
-        el['markup_prefix'] = '&sect;&nbsp;'
+        if el.get('is_section_span'):
+            el['markup_prefix'] = '&sect;&sect;&nbsp;'
+        else:
+            el['markup_prefix'] = '&sect;&nbsp;'
     elif el.get('is_subterp'):
         el['markup_prefix'] = 'Interpretations For '
     el['url'] = SectionUrl.of(el['index'], version, sectional=True)

--- a/regulations/views/navigation.py
+++ b/regulations/views/navigation.py
@@ -9,11 +9,10 @@ def get_labels(current):
 def _add_extra(el, version):
     """Add extra fields to a TOC element -- only added to elements we will
     use for prev/next"""
-    if el.get('is_section'):
-        if el.get('is_section_span'):
-            el['markup_prefix'] = '&sect;&sect;&nbsp;'
-        else:
-            el['markup_prefix'] = '&sect;&nbsp;'
+    if el.get('is_section_span'):
+        el['markup_prefix'] = '&sect;&sect;&nbsp;'
+    elif el.get('is_section'):
+        el['markup_prefix'] = '&sect;&nbsp;'
     elif el.get('is_subterp'):
         el['markup_prefix'] = 'Interpretations For '
     el['url'] = SectionUrl.of(el['index'], version, sectional=True)


### PR DESCRIPTION
Render section spans in:
    - the TOC
    - the Previous/Next section navigation links

Section spans are identified by titles of the form
"§§ <reg>.<section_start>-<section_end>"