### PR TITLE
Return color to rhs definition while loading

### DIFF
--- a/regulations/static/regulations/css/scss/partials/_sidebar.scss
+++ b/regulations/static/regulations/css/scss/partials/_sidebar.scss
@@ -58,7 +58,8 @@ Sidebar Expandables
 -------------------
 */
 
-  .expandable, .open-definition .group {
+  // @todo generalize this so that the id isn't required
+  .expandable, #definition .group {
     cursor: pointer;
     background-color: $gray_lightest;
     width: 100%;

--- a/regulations/static/regulations/js/source/views/sidebar/definition-view.js
+++ b/regulations/static/regulations/js/source/views/sidebar/definition-view.js
@@ -57,7 +57,7 @@ var DefinitionView = Backbone.View.extend({
 
     // temporary header w/spinner while definition is loading
     renderHeader: function() {
-        this.$el.html('<div class="sidebar-header group spinner"><h4>Defined Term</h4></div>');
+        this.$el.html('<header class="group spinner"><h4>Defined Term</h4></header>');
     },
 
     render: function(html) {


### PR DESCRIPTION
The markup and CSS rules around the rhs definition loading were standardized
a bit in #461. Those tweaks didn't account for the short-lived header that
appears while loading the definitions (nor the header that appears when
there's a network error). This modifies the stylesheet to apply to those
situations as well. It also makes the JS tags match the later markup