### PR TITLE
Add a "CURRENT" redirect

### DIFF
--- a/regulations/tests/views_redirect_tests.py
+++ b/regulations/tests/views_redirect_tests.py
@@ -1,3 +1,4 @@
+from datetime import date, timedelta
 from unittest import TestCase
 
 from django.test import RequestFactory
@@ -32,6 +33,21 @@ class ViewsRedirectTest(TestCase):
         response = redirect.redirect_by_date(None, '8888', '2010', '06', '08')
         self.assertEqual(302, response.status_code)
         self.assertTrue('ccc' in response['Location'])
+
+    @patch('regulations.views.redirect.ApiReader')
+    def test_redirect_by_current_date(self, ApiReader):
+        today = date.today()
+        last_week = (today - timedelta(7)).isoformat()
+        next_week = (today + timedelta(7)).isoformat()
+        ApiReader.return_value.regversions.return_value = {'versions': [
+            {'by_date': last_week, 'version': 'last_week'},
+            {'by_date': today.isoformat(), 'version': 'today'},
+            {'by_date': next_week, 'version': 'next_week'},
+        ]}
+
+        response = redirect.redirect_by_current_date(None, '8888')
+        self.assertEqual(302, response.status_code)
+        self.assertTrue('today' in response['Location'])
 
     @patch('regulations.views.redirect.redirect_by_date')
     def test_redirect_by_date_get(self, redirect_by_date):

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -18,8 +18,12 @@ from regulations.views.partial_sxs import ParagraphSXSView
 from regulations.views.preamble import (
     CFRChangesView, PreambleView, PrepareCommentView,
     ChromePreambleSearchView)
-from regulations.views.redirect import diff_redirect, redirect_by_date
-from regulations.views.redirect import redirect_by_date_get
+from regulations.views.redirect import (
+    diff_redirect,
+    redirect_by_current_date,
+    redirect_by_date,
+    redirect_by_date_get
+)
 from regulations.views.sidebar import SideBarView
 from regulations.views.universal_landing import universal
 from regulations.views import comment
@@ -88,6 +92,10 @@ urlpatterns = [
     # Example: http://.../201-3-v/1999/11/8
     url(r'^%s/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})$'
         % paragraph_pattern, redirect_by_date, name='redirect_by_date'),
+    # Redirect to version by current date
+    # Example: http://.../201-3-v/CURRENT
+    url(r'^%s/CURRENT$' % paragraph_pattern,
+        redirect_by_current_date, name='redirect_by_current_date'),
     # A regulation section with chrome
     # Example: http://.../201-4/2013-10704
     url(r'^%s/%s$' % (section_pattern, version_pattern),


### PR DESCRIPTION
If no version is specified, redirect to the currently effective version.

Fixes 18F/atf-eregs#257