### PR TITLE
Bump version to 6.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="regulations",
-    version="master",
+    version="6.1.0",
     packages=find_packages(),
     install_requires=[
         'boto3',


### PR DESCRIPTION
Release Notes:
    - Add a "CURRENT" redirect. If no version is specified, redirect to the currently effective version.