### PR TITLE
Add more middleware, security settings

### DIFF
--- a/regulations/settings/base.py
+++ b/regulations/settings/base.py
@@ -117,12 +117,18 @@ TEMPLATES = [
 ]
 
 
-# Note order:
-# https://docs.djangoproject.com/en/1.8/topics/cache/#the-per-site-cache
+# Order from
+# https://docs.djangoproject.com/en/1.9/ref/middleware/#middleware-ordering
 MIDDLEWARE_CLASSES = (
+    'django.middleware.security.SecurityMiddleware',
     'django.middleware.cache.UpdateCacheMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
 )
 

--- a/regulations/settings/base.py
+++ b/regulations/settings/base.py
@@ -135,6 +135,11 @@ MIDDLEWARE_CLASSES = (
 ROOT_URLCONF = 'regulations.urls'
 
 INSTALLED_APPS = (
+    # Note: no admin
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
     'django.contrib.staticfiles',
     'regulations.apps.RegulationsConfig',
 )

--- a/regulations/settings/base.py
+++ b/regulations/settings/base.py
@@ -132,6 +132,9 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.cache.FetchFromCacheMiddleware',
 )
 
+SECURE_BROWSER_XSS_FILTER = True
+SECURE_CONTENT_TYPE_NOSNIFF = True
+
 ROOT_URLCONF = 'regulations.urls'
 
 INSTALLED_APPS = (


### PR DESCRIPTION
This loads in standard Django middleware and apps to provide better security headers. None of this increases security at _this_ stage (we don't have users or authenticated actions), but we do expect to see more functionality in this direction in the future. Best get on good footing now. It also boosts our static analysis results :)

Adding these changes into -site (rather than downstream repos) to set a solid baseline for everyone.