### PR TITLE
Ensure the Search results view sets a string id.

### DIFF
--- a/regulations/static/regulations/js/source/views/main/search-results-view.js
+++ b/regulations/static/regulations/js/source/views/main/search-results-view.js
@@ -18,6 +18,10 @@ const SearchResultsView = ChildView.extend({
 
   initialize: function initialize(options, ...args) {
     this.options = options;
+    if (!this.options.id && this.options.docId) {
+      this.options.id = this.options.docId.toString();
+    }
+    this.options.id = this.options.id || '';
     this.query = this.options.query;
     // the TOC may link to a different reg version than this.options.resultsRegVersion
     // because the user can select a different version to pull search results from

--- a/regulations/static/regulations/js/unittests/specs/views/search-results-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/search-results-view-spec.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import jsdom from 'mocha-jsdom';
+import { createStore } from 'redux';
+
+import { setStorage } from '../../../source/redux/storage';
+
+
+describe('SearchResultsView', () => {
+  jsdom();
+  let Backbone;
+  let $;
+  let SearchResultsView;
+
+  before(() => {
+    Backbone = require('backbone');
+    $ = require('jquery');
+    Backbone.$ = $;
+    SearchResultsView = require('../../../source/views/main/search-results-view');
+    setStorage(createStore(state => state, {}));
+  });
+
+  describe('::initialize', () => {
+    it('does not modify the id option, if given', () => {
+      const view = new SearchResultsView(
+        { id: 'some-id', docId: 'something-else' });
+      expect(view.options.id).to.equal('some-id');
+    });
+
+    it('sets the id to the string version of the docId', () => {
+      const view = new SearchResultsView({ docId: 1234 });
+      expect(view.options.id).to.equal('1234');
+    });
+
+    it('sets the id to an empty string otherwise', () => {
+      const view = new SearchResultsView({});
+      expect(view.options.id).to.equal('');
+    });
+  });
+});


### PR DESCRIPTION
We assume that the `id` field is set much later (when handling navigation
events), so we'll need to set it here.

This solves an issue where the second page of search results causes a JS error. To recreate, load a search result with more than one page, refresh when on the first page, then click to the second page.