### PR TITLE
Check the correct version parameter in search.

### DIFF
--- a/docs/regulations.rst
+++ b/docs/regulations.rst
@@ -18,6 +18,14 @@ Subpackages
 Submodules
 ----------
 
+regulations\.all\_urls module
+-----------------------------
+
+.. automodule:: regulations.all_urls
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 regulations\.apps module
 ------------------------
 

--- a/regulations/static/config/package.json
+++ b/regulations/static/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regulations-site",
-  "version": "7.0.2",
+  "version": "8.1.0",
   "homepage": "https://eregs.github.io/",
   "contributors": [
     {

--- a/regulations/static/regulations/js/source/router.js
+++ b/regulations/static/regulations/js/source/router.js
@@ -71,7 +71,7 @@ if (typeof window.history.pushState === 'undefined') {
     loadSearchResults: function loadSearchResults(docType, reg, params) {
       const config = {
         query: params.q,
-        regVersion: params.regVersion,
+        regVersion: params.version,
         docType,
       };
 

--- a/regulations/static/regulations/js/unittests/specs/router-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/router-spec.js
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import jsdom from 'mocha-jsdom';
+import sinon from 'sinon';
+
+describe('RegRouter', () => {
+  jsdom();
+  let MainEvents;
+  let RegRouter;
+  let triggerStub;
+
+  before(() => {
+    MainEvents = require('../../source/events/main-events');
+    RegRouter = require('../../source/router');
+    triggerStub = sinon.stub(MainEvents, 'trigger');
+    window.history.pushState = true;
+  });
+
+  describe('::loadSearchResults', () => {
+    it('passes along the correct variables', () => {
+      RegRouter.loadSearchResults(
+        'aDocType', 'aReg', { q: 'terms here', version: 'aVersion' });
+      expect(triggerStub).to.have.been.calledWith(
+        'search-results:open',
+        null,
+        { query: 'terms here', regVersion: 'aVersion', docType: 'aDocType' },
+        'search-results');
+    });
+
+    it('passes along the page, if present', () => {
+      RegRouter.loadSearchResults(
+        'aDocType',
+        'aReg',
+        { q: 'terms here', version: 'aVersion', page: '4', ignored: 'aaa' });
+      expect(triggerStub).to.have.been.calledWith(
+        'search-results:open',
+        null,
+        { query: 'terms here',
+          regVersion: 'aVersion',
+          docType: 'aDocType',
+          page: '4' },
+        'search-results');
+    });
+  });
+});

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="regulations",
-    version="8.0.0",
+    version="8.1.0",
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
Here, `params` refers to URL params, not the internal `config` objects we pass
around. Unfortunately, they have two slightly different sets of field names.

This solves an issue with the back-button when used in Search. See 18F/atf-eregs#499 for reproduction (this is bug 2).