### PR TITLE
Remove external link icon from print.

### DIFF
--- a/regulations/static/regulations/css/scss/_print.scss
+++ b/regulations/static/regulations/css/scss/_print.scss
@@ -189,6 +189,9 @@
     background: none;
     padding-right: 0;
   }
+  a.external::after {
+    content: none;
+  }
 
   @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
     a[href^="http://"] {


### PR DESCRIPTION
Before:
<img width="311" alt="screen shot 2017-08-16 at 10 50 14 am" src="https://user-images.githubusercontent.com/326918/29369502-c7feb1b0-8270-11e7-837e-a4dfc8657ba5.png">


After:
<img width="258" alt="screen shot 2017-08-16 at 10 50 32 am" src="https://user-images.githubusercontent.com/326918/29369497-c24254a2-8270-11e7-9a53-c959bffa50ba.png">
