### PR TITLE
Improved search UI

### DIFF
--- a/regulations/static/regulations/css/scss/module/_search-results.scss
+++ b/regulations/static/regulations/css/scss/module/_search-results.scss
@@ -28,7 +28,7 @@ p.search-version {
     margin-top: 2em;
   }
 
-  h3 {
+  h3, h4, h5 {
     @include sans-font-bold;
     margin-bottom: 0;
   }

--- a/regulations/templates/regulations/search-results.html
+++ b/regulations/templates/regulations/search-results.html
@@ -17,7 +17,9 @@ Partial Search Results.
         {% for result in results.results %}
             <li>
             <h3><a href="{{result.url}}" class="internal" data-linked-section="{{result.section_id}}" data-linked-version="{{version}}" data-linked-subsection="{{result.label|join:'-'}}">{{result.header}}</a></h3>
-                <p>{{result.text}}</p>
+              {% if result.subheader %}<h4>{{ result.subheader }}</h4>{% endif %}
+              {% if result.subsubheader %}<h5>{{ result.subsubheader }}</h5>{% endif %}
+              {% if result.text %}<p>{{result.text}}</p>{% endif %}
             </li>
         {% empty %}
             <span class="no-results">Sorry, there are no results in the regulation effective {{version_by_date|date:"n/j/Y"}}.</span>

--- a/regulations/tests/views_partial_search_tests.py
+++ b/regulations/tests/views_partial_search_tests.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 from datetime import date
 
 from mock import Mock
@@ -13,7 +15,7 @@ def test_get(client, monkeypatch):
         'total_hits': 3333,
         'results': [
             {'label': ['111', '22'], 'text': 'tttt', 'version': 'vvv',
-             'title':"consumer's"},
+             'title':"Consumer's"},
             {'label': ['111', '24', 'a'], 'text': 'o', 'version': 'vvv'},
             {'label': ['111', '25'], 'text': 'more', 'version': 'vvv'}
         ]
@@ -29,7 +31,6 @@ def test_get(client, monkeypatch):
     ]
     response = client.get('/partial/search/111?version=vvv&q=none').content
     assert b'111-22' in response
-    assert b'111.22' in response
     assert b'111-24-a' in response
     assert b'111.24(a)' in response
     assert b'111-25' in response
@@ -188,3 +189,34 @@ def test_add_prev_next():
     view.add_prev_next(7, context)
     assert context['previous'] == {'page': 6, 'length': 10}
     assert 'next' not in context
+
+
+def test_add_cfr_headers_no_title():
+    """If no title is present in the result data, we construct one based on
+    its label."""
+    result = partial_search.add_cfr_headers({'label': ['111', '22', 'c', '4']})
+    assert result['header'] == '111.22(c)(4)'
+
+
+def test_add_cfr_headers_section():
+    """If all of the titles are the same (as is the case when a section's
+    intro text matches our search), we don't need to repeat them."""
+    result = partial_search.add_cfr_headers({'title': 'Section 22',
+                                             'match_title': 'Section 22',
+                                             'paragraph_title': 'Section 22'})
+    assert result['header'] == 'Section 22'
+    assert 'subheader' not in result
+    assert 'subsubheader' not in result
+
+
+def test_add_cfr_headers_three_levels():
+    """If the three levels of title are different, we expect them in our
+    results."""
+    result = partial_search.add_cfr_headers({
+        'title': 'Section 22',
+        'match_title': 'A matching heading',
+        'paragraph_title': 'A title for text',
+    })
+    assert result['header'] == 'Section 22'
+    assert result['subheader'] == 'A matching heading'
+    assert result['subsubheader'] == 'A title for text'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="regulations",
-    version="8.1.0",
+    version="8.2.0",
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
Use additional headers, if present and don't include the human-readable label if there's already a title.