### PR TITLE
Add the text of the link to the aria-label.

### DIFF
--- a/regulations/templates/regulations/macros/external_link.html
+++ b/regulations/templates/regulations/macros/external_link.html
@@ -1,3 +1,7 @@
 <a href="{{url}}" class="external {{classes}}" target="_blank"
-   {% if title %}title="{{title}}"{% endif %}
-   aria-label="Link opens in a new window">{{text}}</a>
+   {% if title %}
+   title="{{title}}" aria-label="{{title}}, Link opens in a new window"
+   {% else %}
+   aria-label="{{text}}, Link opens in a new window"
+   {% endif %}
+>{{text}}</a>


### PR DESCRIPTION
Previously, screen readers would only read "Link opens in a new window"
without the link's text.