### PR TITLE
Move z-index rule to better position.

### DIFF
--- a/regulations/static/regulations/css/scss/partials/_drawer.scss
+++ b/regulations/static/regulations/css/scss/partials/_drawer.scss
@@ -64,6 +64,7 @@ Drawer default state
   background-color: $white;
   border-right: 2px solid $panel_border_color;
   border-bottom: 1px solid $panel_border_color;
+  z-index: 100;
 
   .toc-type,
   .toc-subheader {
@@ -73,7 +74,6 @@ Drawer default state
     height: 40px;
     line-height: 40px;
     border-bottom: none;
-    z-index: 100;
     padding: 0 15px;
   }
 


### PR DESCRIPTION
Placing a z-index on a position: relative; element only affects the z ordering
within the element's containing, positioned parent (in this case,
 #table-of-contents, #timeline, etc.). This means that elements outside that
container (such as the timeline navigation) *weren't* respecting this rule.
Moving the rule up resolves the issue.

## Before
![bad-timeline](https://user-images.githubusercontent.com/326918/29730364-e23ac5d4-89ad-11e7-850b-f6c4cb50404e.gif)


## After
![good-timeline](https://user-images.githubusercontent.com/326918/29730473-4e658726-89ae-11e7-96b9-bf4b3688efd0.gif)
