### PR TITLE
Two accessibility improvements

### DIFF
--- a/regulations/static/regulations/css/scss/partials/_drawer-content.scss
+++ b/regulations/static/regulations/css/scss/partials/_drawer-content.scss
@@ -160,7 +160,7 @@ This contains all of the styles specific to the TOC
   @include border-bottom-light ($width: 1px);
   font-size: 1em;
   text-transform: uppercase;
-  color: $gray_dark;
+  color: $gray_darker;
 }
 
 // Highlight the History tab in diff view

--- a/regulations/templates/regulations/svgs/close-caret.svg
+++ b/regulations/templates/regulations/svgs/close-caret.svg
@@ -1,4 +1,4 @@
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 1000 1000" xml:space="preserve">
 <path d="M689.6,0c31.2,0,62.3,11.9,86.2,35.7c47.7,47.7,47.7,124.9,0,172.5L483.9,500l291.8,291.8
 	c47.7,47.6,47.7,124.8,0,172.4c-47.5,47.6-124.7,47.7-172.3,0.1L225.2,586.2c-22.9-22.8-35.7-53.9-35.7-86.2

--- a/regulations/templates/regulations/svgs/open-caret.svg
+++ b/regulations/templates/regulations/svgs/open-caret.svg
@@ -1,4 +1,4 @@
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 1000 1000" xml:space="preserve">
 <path d="M311.4,1000c-31.2,0-62.3-11.9-86.2-35.7c-47.7-47.7-47.7-124.9,0-172.5L517.1,500L225.2,208.1
 	c-47.7-47.6-47.7-124.8,0-172.4C272.7-11.9,350-12,397.5,35.6l378.2,378.1c22.9,22.8,35.7,53.9,35.7,86.2

--- a/regulations/templates/regulations/svgs/search.svg
+++ b/regulations/templates/regulations/svgs/search.svg
@@ -1,4 +1,4 @@
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 1000 1000" xml:space="preserve">
 <path d="M979.5,881.8L636,538.1c36.6-54.7,57.8-120.6,57.8-191.2C693.8,155.6,538.2,0.1,347,0.1
 	C155.4,0.2,0,155.6,0,346.9c0,191.4,155.4,346.9,346.9,346.9c70.4,0,136.4-21.2,191.2-57.7l343.5,343.7

--- a/regulations/templates/regulations/svgs/table-of-contents.svg
+++ b/regulations/templates/regulations/svgs/table-of-contents.svg
@@ -1,4 +1,4 @@
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 1403.5 1000" xml:space="preserve">
 <g>
 	<path d="M1298.2,210H479.3c-58.2,0-105.1-47-105.1-105.1c0-58.2,46.9-105.1,105.1-105.1h818.9

--- a/regulations/templates/regulations/svgs/timeline.svg
+++ b/regulations/templates/regulations/svgs/timeline.svg
@@ -1,4 +1,4 @@
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 1417.8 1000" xml:space="preserve">
 <g>
 	<path d="M318.3,634.2c-3.1,0-6.5-0.6-9.6-1.8c-9.4-4-15.5-13-15.5-23.3V399.2c0-13.9,11.2-25.1,25.1-25.1


### PR DESCRIPTION
This resolves the two remaining "errors" (the worst category) of issues raised by [HTML_Codesniffer)(http://squizlabs.github.io/HTML_CodeSniffer/).

## Before
<img width="238" alt="screen shot 2017-08-29 at 9 46 53 am" src="https://user-images.githubusercontent.com/326918/29824281-167e97e6-8c9f-11e7-8083-13677673c65a.png">

## After
<img width="237" alt="screen shot 2017-08-29 at 9 47 06 am" src="https://user-images.githubusercontent.com/326918/29824274-1394929c-8c9f-11e7-9c41-431ca16ec053.png">
