### PR TITLE
Link to print a whole part

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@ extends: airbnb
 globals:
     document: true
     localStorage: true
+    location: true
     sessionStorage: true
     window: true
     XMLHttpRequest: true

--- a/regulations/generator/sidebar/print_part.py
+++ b/regulations/generator/sidebar/print_part.py
@@ -1,0 +1,15 @@
+from regulations.generator.sidebar.base import SidebarBase
+from regulations.views.utils import regulation_meta
+
+
+class PrintPart(SidebarBase):
+    shorthand = 'print_part'
+
+    def context(self, http_client, request):
+        meta = regulation_meta(self.cfr_part, self.version)
+
+        return {
+            'cfr_title': meta.get('cfr_title_number'),
+            'cfr_part': self.cfr_part,
+            'version': self.version,
+        }

--- a/regulations/settings/base.py
+++ b/regulations/settings/base.py
@@ -250,6 +250,7 @@ DATA_LAYERS = (
 SIDEBARS = (
     'regulations.generator.sidebar.analyses.Analyses',
     'regulations.generator.sidebar.help.Help',
+    'regulations.generator.sidebar.print_part.PrintPart',
 )
 
 ATTACHMENT_BUCKET = os.getenv('S3_BUCKET')

--- a/regulations/static/config/npm-shrinkwrap.json
+++ b/regulations/static/config/npm-shrinkwrap.json
@@ -57,6 +57,11 @@
       "from": "datatables.net@>=1.10.15 <2.0.0",
       "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.15.tgz"
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "from": "decode-uri-component@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz"
+    },
     "delegate": {
       "version": "3.1.3",
       "from": "delegate@>=3.1.2 <4.0.0",
@@ -182,6 +187,11 @@
       "from": "query-command-supported@1.0.0",
       "resolved": "https://registry.npmjs.org/query-command-supported/-/query-command-supported-1.0.0.tgz"
     },
+    "query-string": {
+      "version": "5.0.0",
+      "from": "query-string@latest",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.0.0.tgz"
+    },
     "react": {
       "version": "15.6.1",
       "from": "react@>=15.4.1 <16.0.0",
@@ -216,6 +226,11 @@
       "version": "1.0.3",
       "from": "sprintf-js@>=1.0.2 <1.1.0",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "from": "strict-uri-encode@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
     },
     "symbol-observable": {
       "version": "1.0.4",

--- a/regulations/static/config/package.json
+++ b/regulations/static/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regulations-site",
-  "version": "8.1.0",
+  "version": "8.4.0",
   "homepage": "https://eregs.github.io/",
   "contributors": [
     {

--- a/regulations/static/config/package.json
+++ b/regulations/static/config/package.json
@@ -86,6 +86,7 @@
     "jquery-scrollstop": "^1.2.0",
     "prosemirror": "0.4.0",
     "query-command-supported": "^1.0.0",
+    "query-string": "^5.0.0",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "redux": "^3.6.0",

--- a/regulations/static/regulations/css/scss/partials/_sidebar.scss
+++ b/regulations/static/regulations/css/scss/partials/_sidebar.scss
@@ -4,6 +4,8 @@ Sidebar.scss
 sidebar.scss styles all of the right sidebar content
 */
 
+$icon_size: 18px;
+
 /*
 add a margin to sidebar content
 this offsets the persistent header & ensures long content is inside the viewport
@@ -54,7 +56,7 @@ Sidebar Expandables
 
     a {
       float: right;
-      font-size: 0.875em;
+      font-size: $icon_size;
       line-height: 40px;
       margin-right: 25px;
     }
@@ -200,7 +202,7 @@ Regs Meta contains the sub-content meta data found in the sidebar
 
     .cf-icon-right {
       float: right;
-      font-size: 0.875em;
+      font-size: $icon_size;
       line-height: 2;
       color: $gray_light;
     }
@@ -384,6 +386,22 @@ Styles for the UI help slide down
   border-top: 1px solid $gray_light;
 }
 
+#print_part {
+  .group {
+    background-color: $gray_lightest;
+    @include border-bottom-light;
+  }
+
+  .cf-icon-print {
+    float: right;
+    color: $action_color;
+    // The print icon is a bit smaller than chevrons; enlarge it
+    font-size: $icon_size + 3;
+    line-height: 40px;
+    margin-right: 15px;
+  }
+}
+
 /*
 Small screens
 ---------------
@@ -471,5 +489,9 @@ Small screens
         margin-right: 10px;
       }
     }
+  }
+
+  #print_part .cf-icon-print {
+    margin-right: 0;
   }
 }

--- a/regulations/static/regulations/js/source/app-init.js
+++ b/regulations/static/regulations/js/source/app-init.js
@@ -3,6 +3,7 @@
 
 const $ = require('jquery');
 const Backbone = require('backbone');
+const queryString = require('query-string');
 const MainView = require('./views/main/main-view');
 const Router = require('./router');
 const SidebarView = require('./views/sidebar/sidebar-view');
@@ -24,6 +25,7 @@ module.exports = {
 
   init: function init() {
     const regs = window.regs || {};
+    const queryParams = queryString.parse(location.search);
 
     Router.start();
     this.bindEvents();
@@ -35,6 +37,11 @@ module.exports = {
     new MainView();
     new SidebarView();
     /* eslint-enable */
+
+    if (queryParams.print === 'true') {
+      window.print();
+    }
+
     setTimeout(() => {
       $('html').addClass('selenium-start');
     }, 5000);

--- a/regulations/templates/regulations/sidebar/print_part.html
+++ b/regulations/templates/regulations/sidebar/print_part.html
@@ -1,0 +1,10 @@
+<section id="print_part" class="regs-meta">
+  <header class="group">
+    <a href="{% url 'chrome_regulation_view' cfr_part version %}?print=true">
+      <h4>
+        Print <strong>{{ cfr_title }} CFR Part {{ cfr_part }}</strong>
+        <span class="cf-icon cf-icon-print" />
+      </h4>
+    </a>
+  </header>
+</section>

--- a/regulations/tests/sidebar_print_part_tests.py
+++ b/regulations/tests/sidebar_print_part_tests.py
@@ -1,0 +1,15 @@
+from mock import Mock
+
+from regulations.generator.sidebar import print_part
+
+
+def test_print_part(monkeypatch):
+    monkeypatch.setattr(print_part, 'regulation_meta', Mock())
+    print_part.regulation_meta.return_value = {'cfr_title_number': 12}
+
+    sidebar = print_part.PrintPart('333-44', 'vvvv')
+    assert sidebar.context(Mock(), Mock()) == {
+        'cfr_title': 12,
+        'cfr_part': '333',
+        'version': 'vvvv',
+    }

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="regulations",
-    version="8.3.0",
+    version="8.4.0",
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
This adds a (default) sidebar link and popups the print dialog whenever "print=true" is a query param.

Looks like 
![print-it](https://user-images.githubusercontent.com/326918/29947539-2354a1ec-8e78-11e7-83ab-f44340f5c6f9.gif)

There is a little jankiness around scroll state (notably, the subheader and position in the table-of-contents don't change as you scroll) on this whole-part page.