### PR TITLE
Ensure footnotes template has proper params.

### DIFF
--- a/regulations/templates/regulations/footnotes.html
+++ b/regulations/templates/regulations/footnotes.html
@@ -1,15 +1,19 @@
-  {% if sub_context.node.footnotes %}
-  <div class="footnote-box">
-      <h5>Footnotes</h5>
-      <ul class="footnotes">
-          {% for footnote in sub_context.node.footnotes %}
-          <li id="footnote-{{footnote.ref}}">
-              <span class="reference-num">{{footnote.ref}}.</span>
-              <p>
-                  {{footnote.note}}
-              </p>
-          </li>
-          {% endfor %}
-      </ul>
-  </div>
-  {% endif %}
+{% comment %}
+Lists footnotes at the bottom of a section. Assumes the "footnotes" variable
+is defined as a list.
+{% endcomment %}
+{% if footnotes %}
+<div class="footnote-box">
+    <h5>Footnotes</h5>
+    <ul class="footnotes">
+        {% for footnote in footnotes %}
+        <li id="footnote-{{footnote.ref}}">
+            <span class="reference-num">{{footnote.ref}}.</span>
+            <p>
+                {{footnote.note}}
+            </p>
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -17,7 +17,7 @@
       {% endif %}
     </div>
 
-    {% include "regulations/footnotes.html" %}
+    {% include "regulations/footnotes.html" with footnotes=sub_context.node.footnotes only %}
     {% include "regulations/navigation.html" %}
   </div>
 

--- a/regulations/templates/regulations/regulation_text.html
+++ b/regulations/templates/regulations/regulation_text.html
@@ -33,7 +33,7 @@
             {% endwith %}
         {% endif %}
 
-    {% include "regulations/footnotes.html" %}
+    {% include "regulations/footnotes.html" with footnotes=c.footnotes only %}
 
 </section>
 {% endif %}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="regulations",
-    version="8.4.0",
+    version="8.4.1",
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
We unintentionally broke regulation footnotes in #235 by changing variable
names. This should set things right by being more explicit about our
parameters.