### PR TITLE
Throw 404 for missing data

### DIFF
--- a/regulations/settings/base.py
+++ b/regulations/settings/base.py
@@ -27,7 +27,7 @@ DATABASES = {
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["*"]
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name

--- a/regulations/tests/views_chrome_tests.py
+++ b/regulations/tests/views_chrome_tests.py
@@ -52,6 +52,20 @@ def test_chrome_404(monkeypatch, rf):
     assert response.status_code == 404
 
 
+def test_chrome_empty_meta(monkeypatch, rf):
+    """Return 404 when trying to access missing regulation.
+    In this situation, `regulation_meta` returns {} """
+
+    chrome_view = chrome.ChromeView()
+
+    monkeypatch.setattr(chrome, 'fetch_grouped_history', Mock())
+    monkeypatch.setattr(chrome, 'fetch_toc', Mock(return_value=[]))
+    monkeypatch.setattr(chrome.utils, 'regulation_meta', Mock(return_value={}))
+
+    with pytest.raises(error_handling.MissingContentException):
+        chrome_view.set_chrome_context({}, '2', 'version')
+
+
 def test_chrome_error_propagation(monkeypatch, rf):
     """While we don't rely on this sort of propagation for the main content
     (much), test it in the sidebar"""

--- a/regulations/views/chrome.py
+++ b/regulations/views/chrome.py
@@ -110,6 +110,11 @@ class ChromeView(TemplateView):
         context['TOC'] = toc
 
         context['meta'] = utils.regulation_meta(reg_part, version)
+
+        # Throw 404 if regulation doesn't exist
+        if not context['meta']:
+            raise error_handling.MissingContentException()
+
         context['version_span'] = version_span(
             context['history'], context['meta']['effective_date'])
         context['version_switch_view'] = self.version_switch_view


### PR DESCRIPTION
### Add error handling for missing regulations
    
- Addresses issue #485: Missing data leads to an explosion
- Also addresses FEC issue: https://github.com/fecgov/fec-eregs/issues/385
    
- Throw a 404 error when navigating to a regulation that doesn't exist
- Previously, the `utils.regulation_meta` function was returning `{}`, so accessing the 'meta' data was resulting in a 500 error

### Allow site to respond to all hosts
    
- Accessing the site was causing an error
- Previously, we needed to add 0.0.0.0 to `ALLOWED_HOSTS` manually.