### PR TITLE
Fix dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PIP_PACKAGE=python${PYTHON3}-pip \
 RUN apt-get update \
     && apt-get install -y $PIP_PACKAGE \
     && rm -rf /var/lib/apt/lists/*
-RUN $PIP_CMD install --upgrade pip
+RUN $PIP_CMD install --upgrade pip setuptools
 RUN npm install --quiet -g grunt-cli
 
 COPY ["manage.py", "package.json", "example-config.json", "setup.py", "frontendbuild.sh", "Gruntfile.js", ".babelrc", ".eslintignore", ".eslintrc", "/app/src/"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository is part of a larger eRegulations project. To read about it, plea
 This library requires
 * Python 2.7, 3.4, 3.5, or 3.6
 * Django 1.8, 1.9, 1.10, or 1.11
+* setuptools v20.5 or later
 * Node 6 or later
 
 ## API Docs

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ setup(
     install_requires=[
         'cached-property',
         'django>=1.8,<1.12',
-        'enum34',
-        'futures',
+        'enum34;python_version<"3.4"',
+        'futures;python_version<"3"',
         'requests',
         'six',
     ],


### PR DESCRIPTION
Newer versions of `futures` will explode if trying to install into Python 3, so this limits installation to appropriate versions of Python. Unfortunately, the syntax used was only added to `setuptools` in 2016, so this also adds a note about updating that.