### PR TITLE
Bump patch version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="regulations",
-    version="8.4.1",
+    version="8.4.2",
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
Bug Fixes
* Ensure compatibility with recent versions of futures/enum34 #516
* Avoid 500 when missing data #515 (thanks to first time contributor,
 @lbeaufort!)
* Fix bug which would turn `&section` links into `&sect;` #519